### PR TITLE
Allow external links for consensus-specs repo

### DIFF
--- a/eipw-lint/src/lints/markdown/relative_links.rs
+++ b/eipw-lint/src/lints/markdown/relative_links.rs
@@ -24,8 +24,11 @@ pub struct RelativeLinks;
 impl Lint for RelativeLinks {
     fn lint<'a, 'b>(&self, slug: &'a str, ctx: &Context<'a, 'b>) -> Result<(), Error> {
         let re = Regex::new(r"(^/)|(://)|(^www)|^(\w)+\.(\w)+").unwrap();
-        let cs_re = Regex::new("^https://(www\\.)?github\\.com/ethereum/consensus-specs/blob/[a-f0-9]{40}/.+$").unwrap();
-        
+        let cs_re = Regex::new(
+            "^https://(www\\.)?github\\.com/ethereum/consensus-specs/blob/[a-f0-9]{40}/.+$",
+        )
+        .unwrap();
+
         let mut visitor = Visitor::default();
         ctx.body().traverse().visit(&mut visitor)?;
 

--- a/eipw-lint/src/lints/markdown/relative_links.rs
+++ b/eipw-lint/src/lints/markdown/relative_links.rs
@@ -23,9 +23,8 @@ pub struct RelativeLinks;
 
 impl Lint for RelativeLinks {
     fn lint<'a, 'b>(&self, slug: &'a str, ctx: &Context<'a, 'b>) -> Result<(), Error> {
-        let re = Regex::new("(^/)|(://)").unwrap();
-
-        let cs_re = Regex::new(r"^https://(www\.)?github\.com/ethereum/consensus-specs(/|$)").unwrap();
+        let re = Regex::new(r"(^/)|(://)|(^www)|^(\w)+\.(\w)+").unwrap();
+        let cs_re = Regex::new("^https://(www\\.)?github\\.com/ethereum/consensus-specs/blob/[a-f0-9]{40}/.+$").unwrap();
         
         let mut visitor = Visitor::default();
         ctx.body().traverse().visit(&mut visitor)?;

--- a/eipw-lint/src/lints/markdown/relative_links.rs
+++ b/eipw-lint/src/lints/markdown/relative_links.rs
@@ -23,7 +23,7 @@ pub struct RelativeLinks;
 
 impl Lint for RelativeLinks {
     fn lint<'a, 'b>(&self, slug: &'a str, ctx: &Context<'a, 'b>) -> Result<(), Error> {
-        let re = Regex::new(r"(^/)|(://)|(^www)|^(\w)+\.(\w)+").unwrap();
+        let re = Regex::new("(^/)|(://)").unwrap();
         let cs_re = Regex::new(
             "^https://(www\\.)?github\\.com/ethereum/consensus-specs/blob/[a-f0-9]{40}/.+$",
         )

--- a/eipw-lint/src/lints/markdown/relative_links.rs
+++ b/eipw-lint/src/lints/markdown/relative_links.rs
@@ -25,13 +25,15 @@ impl Lint for RelativeLinks {
     fn lint<'a, 'b>(&self, slug: &'a str, ctx: &Context<'a, 'b>) -> Result<(), Error> {
         let re = Regex::new("(^/)|(://)").unwrap();
 
+        let cs_re = Regex::new(r"^https://(www\.)?github\.com/ethereum/consensus-specs(/|$)").unwrap();
+        
         let mut visitor = Visitor::default();
         ctx.body().traverse().visit(&mut visitor)?;
 
         let links = visitor
             .links
             .into_iter()
-            .filter(|l| re.is_match(&l.address));
+            .filter(|l| re.is_match(&l.address) && !cs_re.is_match(&l.address));
 
         for Link { line_start, .. } in links {
             ctx.report(Snippet {

--- a/eipw-lint/tests/lint_markdown_relative_links.rs
+++ b/eipw-lint/tests/lint_markdown_relative_links.rs
@@ -9,6 +9,27 @@ use eipw_lint::reporters::Text;
 use eipw_lint::Linter;
 
 #[tokio::test]
+async fn inline_link_to_consensus_specs() {
+    let src = r#"---
+header: value1
+---
+
+[hi](https://github.com/ethereum/consensus-specs/blob/6c2b46ae3248760e0f6e52d61077d8b31e43ad1d/specs/eip4844/validator.md#compute_aggregated_poly_and_commitment)
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny("markdown-rel", RelativeLinks)
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(reports, "");
+}
+
+#[tokio::test]
 async fn inline_link_with_scheme() {
     let src = r#"---
 header: value1


### PR DESCRIPTION
Adds exception in the lint for relative links. Quick solution with additional regex allows links pointing to github.com/ethereum/consensus-specs. 