### PR TITLE
Add new lint for space in Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ error[preamble-order]: preamble header `description` must come after `title`
 | `markdown-refs`                     | ERCs are referenced using ERC-X, while other proposals use EIP-X.                             |
 | `markdown-rel-links`                | All URLs in the page are relative.                                                            |
 | `markdown-req-section`              | Required sections are present in the body of the proposal.                                    |
+| `markdown-headings-space`           | Headers have a space after the leading '#' characters                                           |
 | `preamble-author`                   | The author header is correctly formatted, and there is at least one GitHub user listed.       |
 | `preamble-date-created`             | The `created` header is a date.                                                               |
 | `preamble-date-last-call-deadline`  | The `last-call-deadline` header is a date.                                                    |

--- a/docs/markdown-headings-space/index.html
+++ b/docs/markdown-headings-space/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<title>markdown-headings-space</title>
+		<link rel="stylesheet" href="../main.css">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+	</head>
+	<body>
+		<article>
+			<h1><code>markdown-headings-space</code></h1>
+			<p>
+				Markdown headers must have a space after the hash characters.
+			</p>
+
+			<section>
+				<h2>Examples</h2>
+
+				<pre>error[markdown-headings-space]: Space missing in header
+  |
+5 | ##Banana
+  |  ^ space required here
+  |
+6 | ####Mango
+  |    ^ space required here
+  |
+			</pre>
+			</section>
+			<section>
+				<h2>Explanation</h2>
+
+				<p>
+					<code>markdown-headings-space</code> ensures that all headers
+					have a space after the hash characters so that they are valid.
+				</p>
+
+				<p>
+					The lack of a space makes headers invalid, and they will not be rendered as such.
+				</p>
+			</section>
+		</article>
+	</body>
+</html>

--- a/eipw-lint/src/lib.rs
+++ b/eipw-lint/src/lib.rs
@@ -457,6 +457,10 @@ pub fn default_lints_enum() -> impl Iterator<Item = (&'static str, DefaultLint<&
                 ),
             }),
         ),
+        (
+            "markdown-headings-space",
+            MarkdownHeadingsSpace(markdown::HeadingsSpace{}),
+        )
     ]
     .into_iter()
 }

--- a/eipw-lint/src/lints/known_lints.rs
+++ b/eipw-lint/src/lints/known_lints.rs
@@ -68,6 +68,7 @@ pub enum DefaultLint<S> {
     MarkdownSectionRequired {
         sections: markdown::SectionRequired<S>,
     },
+    MarkdownHeadingsSpace(markdown::HeadingsSpace),
 }
 
 impl<S> DefaultLint<S>
@@ -110,6 +111,7 @@ where
             Self::MarkdownRelativeLinks(l) => Box::new(l),
             Self::MarkdownSectionOrder { sections } => Box::new(sections),
             Self::MarkdownSectionRequired { sections } => Box::new(sections),
+            Self::MarkdownHeadingsSpace(l) => Box::new(l),
         }
     }
 }
@@ -148,6 +150,7 @@ where
             Self::MarkdownRelativeLinks(l) => l,
             Self::MarkdownSectionOrder { sections } => sections,
             Self::MarkdownSectionRequired { sections } => sections,
+            Self::MarkdownHeadingsSpace(l) => l,
         }
     }
 }
@@ -278,6 +281,7 @@ where
             Self::MarkdownSectionRequired { sections } => DefaultLint::MarkdownSectionRequired {
                 sections: markdown::SectionRequired(sections.0.iter().map(AsRef::as_ref).collect()),
             },
+            Self::MarkdownHeadingsSpace(l) => DefaultLint::MarkdownHeadingsSpace(l.clone()),
         }
     }
 }

--- a/eipw-lint/src/lints/markdown.rs
+++ b/eipw-lint/src/lints/markdown.rs
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+pub mod headings_space;
 pub mod html_comments;
 pub mod json_schema;
 pub mod link_first;
@@ -14,6 +15,7 @@ pub mod relative_links;
 pub mod section_order;
 pub mod section_required;
 
+pub use self::headings_space::HeadingsSpace;
 pub use self::html_comments::HtmlComments;
 pub use self::json_schema::JsonSchema;
 pub use self::link_first::LinkFirst;

--- a/eipw-lint/src/lints/markdown/headings_space.rs
+++ b/eipw-lint/src/lints/markdown/headings_space.rs
@@ -7,8 +7,7 @@
 use annotate_snippets::snippet::{Annotation, Slice, Snippet};
 
 use annotate_snippets::snippet::SourceAnnotation;
-use comrak::nodes::Ast;
-use comrak::nodes::NodeValue;
+use comrak::nodes::{Ast, LineColumn, NodeValue, Sourcepos};
 use regex::Regex;
 
 use crate::lints::{Context, Error, Lint};
@@ -32,6 +31,11 @@ impl Lint for HeadingsSpace {
                 // Collect all matching Text nodes
                 Ast {
                     value: NodeValue::Text(text),
+                    sourcepos:
+                        Sourcepos {
+                            start: LineColumn { column: 1, .. }, // Only match text nodes at the start of the line
+                            ..
+                        },
                     ..
                 } => {
                     if let Some(matched_text) = heading_pattern.find(text) {

--- a/eipw-lint/src/lints/markdown/headings_space.rs
+++ b/eipw-lint/src/lints/markdown/headings_space.rs
@@ -1,0 +1,73 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use annotate_snippets::snippet::{Annotation, Slice, Snippet};
+
+use comrak::nodes::Ast;
+use comrak::nodes::NodeValue;
+
+use crate::lints::{Context, Error, Lint};
+use crate::reporters::text;
+use crate::tree::{self, Next, TraverseExt};
+
+use regex::{Regex, RegexSet};
+
+use scraper::node::Node as HtmlNode;
+use scraper::Html;
+
+use serde::{Deserialize, Serialize};
+
+use snafu::Snafu;
+
+use std::fmt::{Debug, Display};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct HeadingsSpace;
+
+impl Lint for HeadingsSpace {
+    fn lint<'a, 'b>(&self, slug: &'a str, ctx: &Context<'a, 'b>) -> Result<(), Error> {
+        // Collect all headings.
+        let false_headings: Vec<_> = ctx
+        .body()
+        .descendants()
+        .filter_map(|node| match &*node.data.borrow() { 
+            Ast { value: NodeValue::Text(text), .. } => {
+                if text.starts_with("#") {
+                    Some((text.clone(), node.data.borrow().sourcepos.start.line))
+                }
+                else {
+                    None
+                }
+            },
+            _ => None,
+        }).collect();
+
+        let slices = false_headings.iter()
+        .map(|(text, line_start)| {
+            Slice{
+                line_start: line_start.clone(),
+                origin: ctx.origin(),
+                source: text,
+                fold: false,
+                annotations: vec![],
+            }
+        })
+        .collect();
+
+        // Print all false headings
+        ctx.report(Snippet {
+            title: Some(Annotation {
+                    id: Some(slug),
+                    annotation_type: ctx.annotation_type(),
+                    label: Some("Space missing in header"),
+                }),
+                footer: vec![],
+                slices,
+                opt: Default::default(),
+            })?;
+        Ok(())
+    }
+}

--- a/eipw-lint/src/lints/markdown/headings_space.rs
+++ b/eipw-lint/src/lints/markdown/headings_space.rs
@@ -6,68 +6,68 @@
 
 use annotate_snippets::snippet::{Annotation, Slice, Snippet};
 
+use annotate_snippets::snippet::SourceAnnotation;
 use comrak::nodes::Ast;
 use comrak::nodes::NodeValue;
 
 use crate::lints::{Context, Error, Lint};
-use crate::reporters::text;
-use crate::tree::{self, Next, TraverseExt};
-
-use regex::{Regex, RegexSet};
-
-use scraper::node::Node as HtmlNode;
-use scraper::Html;
 
 use serde::{Deserialize, Serialize};
 
-use snafu::Snafu;
-
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct HeadingsSpace;
 
 impl Lint for HeadingsSpace {
     fn lint<'a, 'b>(&self, slug: &'a str, ctx: &Context<'a, 'b>) -> Result<(), Error> {
-        // Collect all headings.
         let false_headings: Vec<_> = ctx
-        .body()
-        .descendants()
-        .filter_map(|node| match &*node.data.borrow() { 
-            Ast { value: NodeValue::Text(text), .. } => {
-                if text.starts_with("#") {
-                    Some((text.clone(), node.data.borrow().sourcepos.start.line))
+            .body()
+            .descendants()
+            .filter_map(|node| match &*node.data.borrow() {
+                // Collect all Text nodes as Markdown does not recognise headings without space
+                Ast {
+                    value: NodeValue::Text(text),
+                    ..
+                } => {
+                    if text.starts_with("#") {
+                        Some((text.clone(), node.data.borrow().sourcepos.start.line))
+                    } else {
+                        None
+                    }
                 }
-                else {
-                    None
+                _ => None,
+            })
+            .collect();
+
+        let slices = false_headings
+            .iter()
+            .map(|(text, line_start)| {
+                let error_idx = text.rfind("#").unwrap();
+                Slice {
+                    line_start: line_start.clone(),
+                    origin: ctx.origin(),
+                    source: text,
+                    fold: false,
+                    annotations: vec![SourceAnnotation {
+                        annotation_type: ctx.annotation_type(),
+                        label: "space required here",
+                        range: (error_idx, error_idx + 1),
+                    }],
                 }
-            },
-            _ => None,
-        }).collect();
+            })
+            .collect();
 
-        let slices = false_headings.iter()
-        .map(|(text, line_start)| {
-            Slice{
-                line_start: line_start.clone(),
-                origin: ctx.origin(),
-                source: text,
-                fold: false,
-                annotations: vec![],
-            }
-        })
-        .collect();
-
-        // Print all false headings
         ctx.report(Snippet {
             title: Some(Annotation {
-                    id: Some(slug),
-                    annotation_type: ctx.annotation_type(),
-                    label: Some("Space missing in header"),
-                }),
-                footer: vec![],
-                slices,
-                opt: Default::default(),
-            })?;
+                id: Some(slug),
+                annotation_type: ctx.annotation_type(),
+                label: Some("Space missing in header"),
+            }),
+            footer: vec![],
+            slices,
+            opt: Default::default(),
+        })?;
         Ok(())
     }
 }

--- a/eipw-lint/tests/lint_markdown_headings_space.rs
+++ b/eipw-lint/tests/lint_markdown_headings_space.rs
@@ -80,8 +80,6 @@ header: value1
 `#world`
 "#;
 
-    println!("{}", src_str);
-
     let reports = Linter::<Text<String>>::default()
         .clear_lints()
         .deny("markdown-headings-space", HeadingsSpace {})

--- a/eipw-lint/tests/lint_markdown_headings_space.rs
+++ b/eipw-lint/tests/lint_markdown_headings_space.rs
@@ -1,0 +1,71 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use eipw_lint::lints::markdown::HeadingsSpace;
+use eipw_lint::reporters::Text;
+use eipw_lint::Linter;
+
+#[tokio::test]
+async fn normal_headings() {
+    let src = r#"---
+header: value1
+---
+
+##Banana
+####Mango
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny("markdown-headings-space", HeadingsSpace{})
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        reports,
+        r#"error[markdown-headings-space]: Space missing in header
+  |
+5 | ##Banana
+  |  ^ space required here
+  |
+6 | ####Mango
+  |    ^ space required here
+  |
+"#
+    );
+}
+
+#[tokio::test]
+async fn abnormal_heading() {
+    let src = r#"---
+header: value1
+---
+
+##B#an#ana
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny("markdown-headings-space", HeadingsSpace{})
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        reports,
+        r#"error[markdown-headings-space]: Space missing in header
+  |
+5 | ##B#an#ana
+  |  ^ space required here
+  |
+"#
+    );
+}

--- a/eipw-lint/tests/lint_markdown_headings_space.rs
+++ b/eipw-lint/tests/lint_markdown_headings_space.rs
@@ -69,3 +69,27 @@ header: value1
 "#
     );
 }
+
+#[tokio::test]
+async fn not_headings() {
+    let src_str = r#"---
+header: value1
+---
+
+*Hello*#world
+`#world`
+"#;
+
+    println!("{}", src_str);
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny("markdown-headings-space", HeadingsSpace {})
+        .check_slice(None, src_str)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(reports, "");
+}

--- a/eipw-lint/tests/lint_markdown_headings_space.rs
+++ b/eipw-lint/tests/lint_markdown_headings_space.rs
@@ -20,7 +20,7 @@ header: value1
 
     let reports = Linter::<Text<String>>::default()
         .clear_lints()
-        .deny("markdown-headings-space", HeadingsSpace{})
+        .deny("markdown-headings-space", HeadingsSpace {})
         .check_slice(None, src)
         .run()
         .await
@@ -52,7 +52,7 @@ header: value1
 
     let reports = Linter::<Text<String>>::default()
         .clear_lints()
-        .deny("markdown-headings-space", HeadingsSpace{})
+        .deny("markdown-headings-space", HeadingsSpace {})
         .check_slice(None, src)
         .run()
         .await


### PR DESCRIPTION
Addresses Issue https://github.com/ethereum/eipw/issues/40

Also have to add docs for the new lint. Is there a cargo command to generate the required `html` file?