### PR TITLE
WiP: comrak sourcepos (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ _Breaks compatibility with `--config`._
  - Report message improvements. ([`8fab180`])
  - Replace `prefix` / `suffix` options with templates. ([`d7dc36b`])
  - `--config` now extends the default configuration instead of replacing it. ([`b693091`])
+ - Report source position for markdown nodes. ([#116])
 
 [`24e5142`]: https://github.com/ethereum/eipw/commit/24e51422403126d3e78a3d9bb1df80c29cc4b085
 [`9812014`]: https://github.com/ethereum/eipw/commit/9812014159fd609c6c3addb21b27f87257ff29c0
@@ -30,6 +31,7 @@ _Breaks compatibility with `--config`._
 [@apeaircreative]: https://github.com/apeaircreative
 [`b693091`]: https://github.com/ethereum/eipw/commit/b6930911a0b91fd71fc16ca924c617f4bdec9b2d
 [`1d595cc`]: https://github.com/ethereum/eipw/commit/1d595cc61ba4f92838096429211d1b475b546d37
+[#116]: https://github.com/ethereum/eipw/pull/116
 
 ## 0.9.0 - 2024-10-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,9 +289,9 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "comrak"
-version = "0.35.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52602e10393cfaaf8accaf707f2da743dc22cbe700a343ff8dbc9e5e04bc6b74"
+checksum = "2a4f05e73ca9a30af27bebc13600f91fd1651b2ec7d139ca82a89df7ca583af1"
 dependencies = [
  "caseless",
  "entities",

--- a/eipw-lint-js/tests/main.rs
+++ b/eipw-lint-js/tests/main.rs
@@ -124,10 +124,12 @@ async fn lint_json_schema() {
 44 | |         "type": "article",
 45 | |         "id": "1",
 46 | |         "URL": "3"
-   | |                  ^
-   | |__________________|
-   |                    "3" is not a "uri"
-   |                    "DOI" is a required property
+47 | |     }
+48 | |     ```
+   | |       ^
+   | |_______|
+   |         "3" is not a "uri"
+   |         "DOI" is a required property
    |
    = help: see https://github.com/ethereum/eipw/blob/master/eipw-lint/src/lints/markdown/json_schema/citation.json
    = help: see https://ethereum.github.io/eipw/markdown-json-cite/"#,
@@ -140,7 +142,7 @@ async fn lint_json_schema() {
                             "label": "\"3\" is not a \"uri\"",
                             "level": "Error",
                             "range": {
-                                "end": 86,
+                                "end": 100,
                                 "start": 0
                             }
                         },
@@ -148,7 +150,7 @@ async fn lint_json_schema() {
                             "label": "\"DOI\" is a required property",
                             "level": "Error",
                             "range": {
-                                "end": 86,
+                                "end": 100,
                                 "start": 0
                             }
                         }
@@ -156,7 +158,7 @@ async fn lint_json_schema() {
                     "fold": false,
                     "line_start": 42,
                     "origin": "tests/eips/eip-2000.md",
-                    "source": "    ```csl-json\n    {\n        \"type\": \"article\",\n        \"id\": \"1\",\n        \"URL\": \"3\""
+                    "source": "    ```csl-json\n    {\n        \"type\": \"article\",\n        \"id\": \"1\",\n        \"URL\": \"3\"\n    }\n    ```"
                 }
             ],
             "title": "code block of type `csl-json` does not conform to required schema"

--- a/eipw-lint/Cargo.toml
+++ b/eipw-lint/Cargo.toml
@@ -23,7 +23,7 @@ serde = { workspace = true, features = [ "derive" ] }
 tokio = { optional = true, workspace = true, features = [ "macros" ] }
 figment.workspace = true
 
-comrak = { version = "0.35.0", default-features = false }
+comrak = { version = "0.37.0", default-features = false }
 url = "2.5.4"
 chrono = { version = "0.4.39", default-features = false }
 educe = { version = "0.6.0", default-features = false, features = [ "Debug" ] }

--- a/eipw-lint/src/lib.rs
+++ b/eipw-lint/src/lib.rs
@@ -534,6 +534,12 @@ fn process<'a>(
         } else {
             data.sourcepos.start.line += preamble_lines;
         }
+
+        if data.sourcepos.end.line == 0 {
+            data.sourcepos.end.line = data.sourcepos.start.line;
+        } else {
+            data.sourcepos.end.line += preamble_lines;
+        }
     }
 
     Ok(Some(InnerContext {

--- a/eipw-lint/src/lints.rs
+++ b/eipw-lint/src/lints.rs
@@ -8,11 +8,12 @@ mod known_lints;
 pub mod markdown;
 pub mod preamble;
 
-use eipw_snippets::{Level, Message};
+use eipw_snippets::{Level, Message, Snippet};
 
-use comrak::nodes::AstNode;
+use comrak::nodes::{Ast, AstNode, LineColumn};
 
 use crate::reporters::{self, Reporter};
+use crate::{LevelExt, SnippetExt};
 
 use educe::Educe;
 
@@ -23,7 +24,6 @@ pub use self::known_lints::DefaultLint;
 use snafu::Snafu;
 
 use std::cell::RefCell;
-use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::ops::Deref;
@@ -90,29 +90,91 @@ where
         &self.inner.preamble
     }
 
-    /// XXX: comrak doesn't include a source field with its `AstNode`, so use
-    ///      this instead. Don't expose it publicly since it's really hacky.
-    ///      Yes, lines start at one.
-    pub(crate) fn line(&self, mut line: usize) -> &'a str {
-        assert_ne!(line, 0);
-        line -= 1;
-        self.inner.source.split('\n').nth(line).unwrap()
+    pub fn line_index(&self, line: usize) -> usize {
+        let src = self.inner.source;
+        let (idx, _) = src
+            .bytes()
+            .enumerate()
+            .filter(|(_, chr)| *chr == b'\n')
+            .take(line - 1)
+            .last()
+            .expect("could not find ast line in source");
+        assert_eq!(src.as_bytes().get(idx), Some(&b'\n'));
+        idx + 1
     }
 
-    /// XXX: comrak doesn't include a source field with its `AstNode`, so use
-    ///      this instead. Don't expose it publicly since it's really hacky.
-    pub(crate) fn source_for_text(&self, line: usize, text: &str) -> String {
-        assert_ne!(line, 0);
+    fn line_column_index(&self, line_column: LineColumn) -> usize {
+        let line_index = self.line_index(line_column.line);
+        line_index + line_column.column - 1
+    }
 
-        let newlines = max(1, text.chars().filter(|c| *c == '\n').count());
+    pub fn ast_source(&self, ast: &Ast) -> &'a str {
+        let start = self.line_column_index(ast.sourcepos.start);
+        let end = self.line_column_index(ast.sourcepos.end);
+        &self.inner.source[start..=end]
+    }
 
-        self.inner
-            .source
-            .split('\n')
-            .skip(line - 1)
-            .take(newlines)
-            .collect::<Vec<_>>()
-            .join("\n")
+    pub fn ast_lines(&self, ast: &Ast) -> &'a str {
+        let line_start_index = self.line_index(ast.sourcepos.start.line);
+        let mut line_end_index = self.line_index(ast.sourcepos.end.line);
+
+        if line_end_index < line_start_index {
+            eprintln!(
+                "KNOWN BUG: end index ({}) of {:?} less than start index ({})",
+                line_end_index, ast.value, line_start_index,
+            );
+            line_end_index = line_start_index;
+        }
+
+        let line_end_index = self.inner.source[line_end_index..]
+            .find('\n')
+            .map(|idx| idx + line_end_index)
+            .unwrap_or_else(|| self.inner.source.len());
+
+        &self.inner.source[line_start_index..line_end_index]
+    }
+
+    pub fn ast_snippet<'l, L: Into<Option<Level>>, O: Into<Option<&'l str>>>(
+        &self,
+        ast: &Ast,
+        level: L,
+        label: O,
+    ) -> Snippet<'l>
+    where
+        'a: 'l,
+    {
+        let line_start_index = self.line_index(ast.sourcepos.start.line);
+        let level = level.into().unwrap_or(self.annotation_level());
+
+        let start_index = self.line_column_index(ast.sourcepos.start) - line_start_index;
+        let end_index = match self.line_column_index(ast.sourcepos.end) {
+            x if x >= line_start_index => x - line_start_index,
+            y => {
+                eprintln!(
+                    "KNOWN BUG: end index ({}) of {:?} less than start index ({})",
+                    y, ast.value, line_start_index,
+                );
+                let mut fake_end = start_index + 1;
+                if fake_end >= self.inner.source.len() {
+                    fake_end = self.inner.source.len() - 1;
+                }
+                fake_end
+            }
+        };
+
+        let source = self.ast_lines(ast);
+        let annotation = level.span_utf8(source, start_index, end_index + 1 - start_index);
+
+        let annotation = match label.into() {
+            None => annotation,
+            Some(label) => annotation.label(label.as_ref()),
+        };
+
+        Snippet::source(source)
+            .fold(true)
+            .line_start(ast.sourcepos.start.line)
+            .origin_opt(self.origin())
+            .annotation(annotation)
     }
 
     pub fn body_source(&self) -> &'a str {
@@ -190,5 +252,189 @@ impl Lint for Box<dyn Lint> {
     fn lint<'a>(&self, slug: &'a str, ctx: &Context<'a, '_>) -> Result<(), Error> {
         let lint: &dyn Lint = self.deref();
         lint.lint(slug, ctx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use comrak::{
+        arena_tree::{Node, NodeEdge},
+        nodes::NodeValue,
+    };
+
+    use super::*;
+
+    fn get_context_ast_source(source: &str, pred: impl FnMut(&Ast) -> bool) -> String {
+        let arena = comrak::Arena::new();
+        let context = Context {
+            annotation_level: Level::Error,
+            eips: &Default::default(),
+            reporter: &crate::reporters::Null,
+            inner: crate::process(&crate::reporters::Null, &arena, Some("eip-1234.md"), source)
+                .unwrap()
+                .unwrap(),
+        };
+
+        let link = context
+            .body()
+            .traverse()
+            .filter_map(|x| match x {
+                NodeEdge::Start(Node { data, .. }) => Some(data.borrow().clone()),
+                _ => None,
+            })
+            .filter(pred)
+            .next()
+            .unwrap();
+
+        context.ast_source(&link).to_owned()
+    }
+
+    #[test]
+    fn context_ast_source_autolink_email() {
+        let source = r#"
+---
+eip: 1234
+---
+
+foo@example.com hello world
+"#
+        .trim();
+
+        let actual = get_context_ast_source(source, |d| matches!(d.value, NodeValue::Link(_)));
+        assert_eq!(actual, "foo@example.com");
+    }
+
+    #[test]
+    fn context_ast_source_link_start() {
+        let source = r#"
+---
+eip: 1234
+---
+
+<https://example.com> hello world
+"#
+        .trim();
+
+        let actual = get_context_ast_source(source, |d| matches!(d.value, NodeValue::Link(_)));
+        assert_eq!(actual, "<https://example.com>");
+    }
+
+    #[test]
+    fn context_ast_source_inline_link_start() {
+        let source = r#"
+---
+eip: 1234
+---
+
+[hello](https://example.com) hello world
+"#
+        .trim();
+
+        let actual = get_context_ast_source(source, |d| matches!(d.value, NodeValue::Link(_)));
+        assert_eq!(actual, "[hello](https://example.com)");
+    }
+
+    #[test]
+    fn context_ast_source_emphasis_unicode() {
+        let source = r#"
+---
+eip: 1234
+---
+
+*áemphá* hello world
+"#
+        .trim();
+
+        let actual = get_context_ast_source(source, |d| matches!(d.value, NodeValue::Emph));
+        assert_eq!(actual, "*áemphá*");
+    }
+
+    #[test]
+    fn context_ast_source_emphasis_start() {
+        let source = r#"
+---
+eip: 1234
+---
+
+*emphasis* hello world
+"#
+        .trim();
+
+        let actual = get_context_ast_source(source, |d| matches!(d.value, NodeValue::Emph));
+        assert_eq!(actual, "*emphasis*");
+    }
+
+    #[test]
+    fn context_ast_source_link_mid() {
+        let source = r#"
+---
+eip: 1234
+---
+
+hello <https://example.com> world
+"#
+        .trim();
+
+        let actual = get_context_ast_source(source, |d| matches!(d.value, NodeValue::Link(_)));
+        assert_eq!(actual, "<https://example.com>");
+    }
+
+    #[test]
+    fn context_ast_source_inline_link_mid() {
+        let source = r#"
+---
+eip: 1234
+---
+
+hello [hello](https://example.com) world
+"#
+        .trim();
+
+        let actual = get_context_ast_source(source, |d| matches!(d.value, NodeValue::Link(_)));
+        assert_eq!(actual, "[hello](https://example.com)");
+    }
+
+    #[test]
+    fn context_ast_source_emphasis_mid() {
+        let source = r#"
+---
+eip: 1234
+---
+
+hello *emphasis* world
+"#
+        .trim();
+
+        let actual = get_context_ast_source(source, |d| matches!(d.value, NodeValue::Emph));
+        assert_eq!(actual, "*emphasis*");
+    }
+
+    #[test]
+    fn context_ast_source_code_block() {
+        let source = r#"
+---
+eip: 1234
+---
+
+hello
+
+```
+this is a
+multiline
+code block
+```
+
+world
+"#
+        .trim();
+
+        let expected = r#"```
+this is a
+multiline
+code block
+```"#;
+
+        let actual = get_context_ast_source(source, |d| matches!(d.value, NodeValue::CodeBlock(_)));
+        assert_eq!(actual, expected);
     }
 }

--- a/eipw-lint/src/lints/markdown/heading_first.rs
+++ b/eipw-lint/src/lints/markdown/heading_first.rs
@@ -7,9 +7,6 @@
 use comrak::nodes::{Ast, NodeValue};
 
 use crate::lints::{Error, Lint};
-use crate::SnippetExt;
-
-use eipw_snippets::Snippet;
 
 use serde::{Deserialize, Serialize};
 
@@ -32,17 +29,11 @@ impl Lint for HeadingFirst {
             other => other,
         };
 
-        let source = ctx.line(ast.sourcepos.start.line);
         ctx.report(
             ctx.annotation_level()
                 .title("Nothing is permitted between the preamble and the first heading")
                 .id(slug)
-                .snippet(
-                    Snippet::source(source)
-                        .origin_opt(ctx.origin())
-                        .line_start(ast.sourcepos.start.line)
-                        .fold(false),
-                ),
+                .snippet(ctx.ast_snippet(&ast, None, None)),
         )?;
 
         Ok(())

--- a/eipw-lint/src/lints/markdown/html_comments.rs
+++ b/eipw-lint/src/lints/markdown/html_comments.rs
@@ -4,14 +4,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use eipw_snippets::{Level, Snippet};
+use eipw_snippets::Level;
 
 use comrak::nodes::NodeValue;
 
-use crate::{
-    lints::{Context, Error, Lint},
-    SnippetExt,
-};
+use crate::lints::{Context, Error, Lint};
 
 use scraper::node::Node as HtmlNode;
 use scraper::Html;
@@ -60,12 +57,7 @@ where
                     continue;
                 }
 
-                slices.push(
-                    Snippet::source(ctx.line(data.sourcepos.start.line))
-                        .line_start(data.sourcepos.start.line)
-                        .fold(false)
-                        .origin_opt(ctx.origin()),
-                );
+                slices.push(ctx.ast_snippet(&data, annotation_type, None));
             }
         }
 

--- a/eipw-lint/src/lints/markdown/json_schema.rs
+++ b/eipw-lint/src/lints/markdown/json_schema.rs
@@ -89,9 +89,6 @@ impl<'a, 'b, 'c> tree::Visitor for Visitor<'a, 'b, 'c> {
             Ok(v) => v,
             Err(e) => {
                 let label = format!("code block of type `{}` does not contain valid JSON", info);
-                let source = self
-                    .ctx
-                    .source_for_text(ast.sourcepos.start.line, &node.literal);
                 let slice_label = e.to_string();
                 self.ctx.report(
                     self.ctx
@@ -99,18 +96,9 @@ impl<'a, 'b, 'c> tree::Visitor for Visitor<'a, 'b, 'c> {
                         .title(&label)
                         .id(self.slug)
                         .snippet(
-                            Snippet::source(&source)
-                                .origin_opt(self.ctx.origin())
-                                // TODO: The serde_json error actually has line/column
-                                //       information. Use it.
-                                .line_start(ast.sourcepos.start.line)
-                                .fold(false)
-                                .annotation(
-                                    self.ctx
-                                        .annotation_level()
-                                        .span(0..source.len())
-                                        .label(&slice_label),
-                                ),
+                            // TODO: The serde_json error actually has line/column
+                            //       information. Use it.
+                            self.ctx.ast_snippet(ast, None, slice_label.as_str()),
                         ),
                 )?;
                 return Ok(Next::SkipChildren);
@@ -126,9 +114,7 @@ impl<'a, 'b, 'c> tree::Visitor for Visitor<'a, 'b, 'c> {
             .into_iter()
             .map(|d| d.error_description().to_string())
             .collect();
-        let source = self
-            .ctx
-            .source_for_text(ast.sourcepos.start.line, &node.literal);
+        let source = self.ctx.ast_lines(ast);
         let annotations = labels
             .iter()
             .map(|l| self.ctx.annotation_level().span(0..source.len()).label(l));
@@ -143,7 +129,7 @@ impl<'a, 'b, 'c> tree::Visitor for Visitor<'a, 'b, 'c> {
                 .title(&label)
                 .id(self.slug)
                 .snippet(
-                    Snippet::source(&source)
+                    Snippet::source(source)
                         .fold(false)
                         .line_start(ast.sourcepos.start.line)
                         .origin_opt(self.ctx.origin())

--- a/eipw-lint/src/lints/markdown/link_first.rs
+++ b/eipw-lint/src/lints/markdown/link_first.rs
@@ -70,6 +70,9 @@ struct Visitor<'a, 'b, 'c> {
 
 impl<'a, 'b, 'c> Visitor<'a, 'b, 'c> {
     fn check(&self, ast: &Ast, text: &str) -> Result<Next, Error> {
+        let source = self.ctx.ast_lines(ast);
+        let offset = source.find(text); // TODO: Calculating the offset like this is a huge hack.
+
         for matched in self.re.captures_iter(text) {
             let self_reference = match self.own_number {
                 None => false,
@@ -94,19 +97,26 @@ impl<'a, 'b, 'c> Visitor<'a, 'b, 'c> {
 
             let footer_label = format!("the pattern in question: `{}`", self.pattern);
 
-            // TODO: Actually annotate the matches.
+            let annotations = match offset {
+                None => None,
+                Some(offset) => {
+                    let start = offset + matched.get(0).unwrap().start();
+                    let end = offset + matched.get(0).unwrap().end();
+                    Some(self.ctx.annotation_level().span(start..end))
+                }
+            };
 
-            let source = self.ctx.source_for_text(ast.sourcepos.start.line, text);
             self.ctx.report(
                 self.ctx
                     .annotation_level()
                     .title("the first match of the given pattern must be a link")
                     .id(self.slug)
                     .snippet(
-                        Snippet::source(&source)
-                            .origin_opt(self.ctx.origin())
+                        Snippet::source(source)
+                            .fold(true)
                             .line_start(ast.sourcepos.start.line)
-                            .fold(false),
+                            .origin_opt(self.ctx.origin())
+                            .annotations(annotations),
                     )
                     .footer(Level::Info.title(&footer_label)),
             )?;

--- a/eipw-lint/src/lints/markdown/link_status.rs
+++ b/eipw-lint/src/lints/markdown/link_status.rs
@@ -4,12 +4,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use eipw_snippets::{Level, Snippet};
+use eipw_snippets::Level;
 
 use comrak::nodes::{Ast, AstNode, NodeValue};
 
 use crate::lints::{Context, Error, FetchContext, Lint};
-use crate::SnippetExt;
 
 use regex::Regex;
 
@@ -43,17 +42,16 @@ where
     fn find_links<'a>(
         &self,
         node: &'a AstNode<'a>,
-    ) -> impl 'a + Iterator<Item = (usize, u32, String)> {
+    ) -> impl 'a + Iterator<Item = (Ast, u32, String)> {
         let re = Regex::new(self.pattern.as_ref()).unwrap();
 
         node.descendants()
             // Find all URLs and the lines they appear on.
             .filter_map(|start| match &*start.data.borrow() {
-                Ast {
+                ast @ Ast {
                     value: NodeValue::Link(link),
-                    sourcepos,
                     ..
-                } => Some((sourcepos.start.line, link.url.clone())),
+                } => Some((ast.clone(), link.url.clone())),
                 _ => None,
             })
             .filter_map(move |(start_line, url)| {
@@ -97,18 +95,16 @@ where
         let my_tier = self.tier(&map, ctx);
         let mut min = usize::MAX;
 
-        for (start_line, number, whole) in self.find_links(ctx.body()) {
+        for (ast, number, whole) in self.find_links(ctx.body()) {
             let eip = match ctx.proposal(number) {
                 Ok(eip) => eip,
                 Err(e) => {
                     let label = format!("unable to read file `{}`: {}", whole, e);
                     ctx.report(
-                        ctx.annotation_level().title(&label).id(slug).snippet(
-                            Snippet::source(ctx.line(start_line))
-                                .fold(false)
-                                .line_start(start_line)
-                                .origin_opt(ctx.origin()),
-                        ),
+                        ctx.annotation_level()
+                            .title(&label)
+                            .id(slug)
+                            .snippet(ctx.ast_snippet(&ast, None, None)),
                     )?;
                     continue;
                 }
@@ -158,12 +154,7 @@ where
                 ctx.annotation_level()
                     .title(&label)
                     .id(slug)
-                    .snippet(
-                        Snippet::source(ctx.line(start_line))
-                            .line_start(start_line)
-                            .fold(false)
-                            .origin_opt(ctx.origin()),
-                    )
+                    .snippet(ctx.ast_snippet(&ast, None, None))
                     .footers(footer),
             )?;
         }

--- a/eipw-lint/src/lints/markdown/no_backticks.rs
+++ b/eipw-lint/src/lints/markdown/no_backticks.rs
@@ -4,13 +4,12 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use eipw_snippets::{Level, Snippet};
+use eipw_snippets::Level;
 
 use comrak::nodes::{Ast, NodeCode};
 
 use crate::lints::{Context, Error, Lint};
 use crate::tree::{self, Next, TraverseExt};
-use crate::SnippetExt;
 
 use ::regex::Regex;
 
@@ -56,18 +55,12 @@ impl<'a, 'b, 'c> Visitor<'a, 'b, 'c> {
         }
 
         let footer_label = format!("the pattern in question: `{}`", self.pattern);
-        let source = self.ctx.source_for_text(ast.sourcepos.start.line, text);
         self.ctx.report(
             self.ctx
                 .annotation_level()
                 .title("proposal references should not be in backticks")
                 .id(self.slug)
-                .snippet(
-                    Snippet::source(&source)
-                        .fold(false)
-                        .line_start(ast.sourcepos.start.line)
-                        .origin_opt(self.ctx.origin()),
-                )
+                .snippet(self.ctx.ast_snippet(ast, None, None))
                 .footer(Level::Info.title(&footer_label)),
         )?;
 

--- a/eipw-lint/src/lints/markdown/regex.rs
+++ b/eipw-lint/src/lints/markdown/regex.rs
@@ -78,21 +78,35 @@ impl<'a, 'b, 'c> ExcludesVisitor<'a, 'b, 'c> {
             return Ok(Next::TraverseChildren);
         }
 
+        let source = self.ctx.ast_lines(ast);
+
+        // TODO: Calculating the offset like this is a huge hack.
+        let annotations = match source.find(buf) {
+            None => vec![],
+            Some(offset) => self
+                .re
+                .find_iter(buf)
+                .map(|m| {
+                    let start = offset + m.start();
+                    let end = offset + m.end();
+                    self.ctx.annotation_level().span(start..end)
+                })
+                .collect(),
+        };
+
         let footer_label = format!("the pattern in question: `{}`", self.pattern);
 
-        // TODO: Actually annotate the matches for `Mode::Excludes`.
-
-        let source = self.ctx.source_for_text(ast.sourcepos.start.line, buf);
         self.ctx.report(
             self.ctx
                 .annotation_level()
                 .title(self.message)
                 .id(self.slug)
                 .snippet(
-                    Snippet::source(&source)
-                        .origin_opt(self.ctx.origin())
+                    Snippet::source(source)
+                        .fold(true)
                         .line_start(ast.sourcepos.start.line)
-                        .fold(false),
+                        .origin_opt(self.ctx.origin())
+                        .annotations(annotations),
                 )
                 .footer(Level::Info.title(&footer_label)),
         )?;

--- a/eipw-lint/src/lints/preamble/required.rs
+++ b/eipw-lint/src/lints/preamble/required.rs
@@ -37,7 +37,7 @@ where
             let label = format!("preamble is missing header(s): `{}`", missing);
             ctx.report(
                 ctx.annotation_level().title(&label).id(slug).snippet(
-                    Snippet::source(ctx.line(1))
+                    Snippet::source("---")
                         .line_start(1)
                         .origin_opt(ctx.origin())
                         .fold(true),

--- a/eipw-lint/tests/eipv/markdown-html-comments/expected.txt
+++ b/eipw-lint/tests/eipv/markdown-html-comments/expected.txt
@@ -1,5 +1,6 @@
 error[markdown-html-comments]: HTML comments are not allowed when `status` is `Last Call`
-  --> input.md
+  --> input.md:16:1
    |
 16 | <!-- This is an html comment -->
+   | ^^
    |

--- a/eipw-lint/tests/eipv/markdown-json-cite/expected.txt
+++ b/eipw-lint/tests/eipv/markdown-json-cite/expected.txt
@@ -6,9 +6,11 @@ error[markdown-json-cite]: code block of type `csl-json` does not conform to req
 44 | |         "type": "article",
 45 | |         "id": "1",
 46 | |         "URL": "3"
-   | |                  ^
-   | |__________________|
-   |                    "3" is not a "uri"
-   |                    "DOI" is a required property
+47 | |     }
+48 | |     ```
+   | |       ^
+   | |_______|
+   |         "3" is not a "uri"
+   |         "DOI" is a required property
    |
    = help: see https://github.com/ethereum/eipw/blob/master/eipw-lint/src/lints/markdown/json_schema/citation.json

--- a/eipw-lint/tests/eipv/markdown-link-too-unstable/expected.txt
+++ b/eipw-lint/tests/eipv/markdown-link-too-unstable/expected.txt
@@ -1,12 +1,14 @@
 error[markdown-link-status]: proposal `eip-20.md` is not stable enough for a `status` of `Last Call`
-  --> input.md
+  --> input.md:15:46
    |
 15 | This is the abstract for the EIP which needs [EIP-20](./eip-20.md).
+   |                                              ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: because of this link, this proposal's `status` must be one of: `Draft`, `Stagnant`
 error[markdown-link-status]: proposal `eip-2048.md` is not stable enough for a `status` of `Last Call`
-  --> input.md
+  --> input.md:21:40
    |
 21 | This is the specification for the EIP, [for some reason](./eip-2048.md).
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: because of this link, this proposal's `status` must be one of: `Draft`, `Stagnant`

--- a/eipw-lint/tests/eipv/markdown-malformed-eip/expected.txt
+++ b/eipw-lint/tests/eipv/markdown-malformed-eip/expected.txt
@@ -1,19 +1,22 @@
 error[markdown-no-backticks]: proposal references should not be in backticks
-  --> input.md
+  --> input.md:18:51
    |
 18 | This is the motivation for the EIP, which extends `ERC-721`.
+   |                                                   ^^^^^^^^^
    |
    = info: the pattern in question: `(?i)(eip|erc)-[0-9]+`
 error[markdown-re-eip-dash]: proposals must be referenced with the form `EIP-N` (not `EIPN` or `EIP N`)
-  --> input.md
+  --> input.md:27:56
    |
 27 | These are the backwards compatibility concerns for the EIP1234.
+   |                                                        ^^^^^^^
    |
    = info: the pattern in question: `(?i)eip[\s]*[0-9]+`
 error[markdown-re-erc-dash]: proposals must be referenced with the form `ERC-N` (not `ERCN` or `ERC N`)
-  --> input.md
+  --> input.md:15:49
    |
 15 | This is the abstract for the EIP, which extends ERC721.
+   |                                                 ^^^^^^
    |
    = info: the pattern in question: `(?i)erc[\s]*[0-9]+`
 error[markdown-spell]: the word `ERC721` is misspelled

--- a/eipw-lint/tests/eipv/markdown-proposal-ref/expected.txt
+++ b/eipw-lint/tests/eipv/markdown-proposal-ref/expected.txt
@@ -1,15 +1,18 @@
 error[markdown-refs]: references to proposals with a `category` of `ERC` must use a prefix of `ERC`
-  --> input.md
+  --> input.md:18:52
    |
 18 | This is the motivation for the EIP, which extends [EIP-721](./eip-721.md).
+   |                                                    ^^^^^^^
    |
 error[markdown-refs]: references to proposals without a `category` must use a prefix of `EIP`
-  --> input.md
+  --> input.md:21:89
    |
 21 | This is the specification for the EIP, which doesn't extend [EIP-123](./eip-123.md) or [ERC-123](./eip-123.md).
+   |                                                                                         ^^^^^^^
    |
 error[markdown-refs]: references to proposals with a `category` of `ERC` must use a prefix of `ERC`
-  --> input.md
+  --> input.md:24:31
    |
 24 | This is the rationale for the EIP-721.
+   |                               ^^^^^^^
    |

--- a/eipw-lint/tests/eipv/markdown-unlinked-eip/expected.txt
+++ b/eipw-lint/tests/eipv/markdown-unlinked-eip/expected.txt
@@ -1,12 +1,14 @@
 error[markdown-link-first]: the first match of the given pattern must be a link
-  --> input.md
+  --> input.md:15:49
    |
 15 | This is the abstract for the EIP, which extends EIP-1234.
+   |                                                 ^^^^^^^^
    |
    = info: the pattern in question: `(?i)(?:eip|erc)-([0-9]+)`
 error[markdown-link-first]: the first match of the given pattern must be a link
-  --> input.md
+  --> input.md:17:54
    |
 17 | This is also the abstract for the EIP, which extends ERC-1236.
+   |                                                      ^^^^^^^^
    |
    = info: the pattern in question: `(?i)(?:eip|erc)-([0-9]+)`

--- a/eipw-lint/tests/lint_markdown_heading_first.rs
+++ b/eipw-lint/tests/lint_markdown_heading_first.rs
@@ -34,7 +34,10 @@ After the "Abstract" heading is the first place we want to allow text."#;
         reports,
         r#"error[markdown-heading-first]: Nothing is permitted between the preamble and the first heading
   |
-5 | This is some text that appears before the first heading. Authors sometimes try
+5 | / This is some text that appears before the first heading. Authors sometimes try
+6 | | to write an introduction or preface to their proposal here. We don't want to allow
+7 | | this.
+  | |_____^
   |
 "#
     );

--- a/eipw-lint/tests/lint_markdown_html_comments.rs
+++ b/eipw-lint/tests/lint_markdown_html_comments.rs
@@ -42,6 +42,7 @@ text after
         r#"warning[markdown-html-comments]: HTML comments are only allowed while `header` is one of: `value1`
   |
 6 | <!-- multi-line
+  | ---------------
   |
 "#
     );
@@ -80,6 +81,7 @@ text after
         r#"error[markdown-html-comments]: HTML comments are not allowed when `header` is `value2`
   |
 6 | <!-- multi-line
+  | ^^^^^^^^^^^^^^^
   |
 "#
     );

--- a/eipw-lint/tests/lint_markdown_json_schema.rs
+++ b/eipw-lint/tests/lint_markdown_json_schema.rs
@@ -41,8 +41,10 @@ header: value1
         reports,
         r#"error[markdown-json-schema]: code block of type `hello` does not contain valid JSON
   |
-5 | ```hello
-  | ^^^^^^^^ EOF while parsing an object at line 2 column 0
+5 | / ```hello
+6 | | {
+7 | | ```
+  | |___^ EOF while parsing an object at line 2 column 0
   |
 "#
     );
@@ -158,8 +160,10 @@ header: value1
         reports,
         r#"error[markdown-json-schema]: code block of type `hello` does not conform to required schema
   |
-5 | ```hello
-  | ^^^^^^^^ 3 is not of type "string"
+5 | / ```hello
+6 | | {"a": 3}
+7 | | ```
+  | |___^ 3 is not of type "string"
   |
   = help: see https://example.com/schema.json
 "#
@@ -209,8 +213,10 @@ header: value1
         reports,
         r#"error[markdown-json-schema]: code block of type `hello` does not conform to required schema
   |
-5 | ```hello
-  | ^^^^^^^^ "3" is not of type "integer"
+5 | / ```hello
+6 | | {"a": "3"}
+7 | | ```
+  | |___^ "3" is not of type "integer"
   |
   = help: see https://example.com/schema.json
 "#

--- a/eipw-lint/tests/lint_markdown_link_first.rs
+++ b/eipw-lint/tests/lint_markdown_link_first.rs
@@ -36,6 +36,7 @@ eip-1234
         r#"error[markdown-link-first]: the first match of the given pattern must be a link
   |
 4 | eip-1234
+  | ^^^^^^^^
   |
   = info: the pattern in question: `(?i)(?:eip|erc)-([0-9]+)`
 "#
@@ -66,6 +67,7 @@ hello
         r#"error[markdown-link-first]: the first match of the given pattern must be a link
   |
 4 | hello
+  |  ^^^^
   |
   = info: the pattern in question: `ello`
 "#

--- a/eipw-lint/tests/lint_markdown_no_backticks.rs
+++ b/eipw-lint/tests/lint_markdown_no_backticks.rs
@@ -36,6 +36,7 @@ hello
         r#"error[markdown-no-backticks]: proposal references should not be in backticks
   |
 7 | `EIP-1234`
+  | ^^^^^^^^^^
   |
   = info: the pattern in question: `EIP-[0-9]+`
 "#

--- a/eipw-lint/tests/lint_markdown_regex.rs
+++ b/eipw-lint/tests/lint_markdown_regex.rs
@@ -39,6 +39,7 @@ header: value1
         r#"error[markdown-re]: boop
   |
 5 | [hi](https://example.com/)
+  |  ^^
   |
   = info: the pattern in question: `hi`
 "#
@@ -104,6 +105,7 @@ hello
         r#"error[markdown-re]: boop
   |
 6 | hello
+  |  ^^^^
   |
   = info: the pattern in question: `ello`
 "#

--- a/eipw-lint/tests/lint_markdown_relative_links.rs
+++ b/eipw-lint/tests/lint_markdown_relative_links.rs
@@ -65,6 +65,7 @@ header: value1
         r#"error[markdown-rel]: non-relative link or image
   |
 5 | [hi](https://example.com/)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^ used here
   |
 "#
     );
@@ -98,6 +99,7 @@ header: value1
         r#"error[markdown-rel]: non-relative link or image
   |
 5 | [hello](https://eips.ethereum.org/EIPS/eip-1234)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ used here
   |
   = help: use `./eip-1234.md` instead
 "#
@@ -132,6 +134,7 @@ header: value1
         r#"error[markdown-rel]: non-relative link or image
   |
 5 | [hello](https://ercs.ethereum.org/ERCS/erc-1234)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ used here
   |
   = help: use `./eip-1234.md` instead
 "#
@@ -166,6 +169,7 @@ header: value1
         r#"error[markdown-rel]: non-relative link or image
   |
 5 | [copyright](https://creativecommons.org/publicdomain/zero/1.0/)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ used here
   |
   = help: use `../LICENSE.md` instead
 "#
@@ -200,6 +204,7 @@ header: value1
         r#"error[markdown-rel]: non-relative link or image
   |
 5 | [hi](https://example.com/4444)
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ used here
   |
 "#
     );
@@ -233,6 +238,7 @@ header: value1
         r#"error[markdown-rel]: non-relative link or image
   |
 5 | [hi](//example.com/)
+  | ^^^^^^^^^^^^^^^^^^^^ used here
   |
 "#
     );
@@ -266,6 +272,7 @@ Hello [hi](/foo)!
         r#"error[markdown-rel]: non-relative link or image
   |
 5 | Hello [hi](/foo)!
+  |       ^^^^^^^^^^ used here
   |
 "#
     );
@@ -327,6 +334,7 @@ Hello [hi][hello]!
         r#"error[markdown-rel]: non-relative link or image
   |
 5 | Hello [hi][hello]!
+  |       ^^^^^^^^^^^ used here
   |
 "#
     );
@@ -390,6 +398,7 @@ Hello [hi][hello]!
         r#"error[markdown-rel]: non-relative link or image
   |
 5 | Hello [hi][hello]!
+  |       ^^^^^^^^^^^ used here
   |
   = help: use `./eip-1234.md` instead
 "#
@@ -426,6 +435,7 @@ Hello [hi][hello]!
         r#"error[markdown-rel]: non-relative link or image
   |
 5 | Hello [hi][hello]!
+  |       ^^^^^^^^^^^ used here
   |
   = help: use `./eip-1234.md` instead
 "#
@@ -462,6 +472,7 @@ hello world
         r#"error[markdown-rel]: non-relative link or image
   |
 5 | https://example.com/
+  | ^^^^^^^^^^^^^^^^^^^^ used here
   |
 "#
     );
@@ -495,6 +506,7 @@ header: value1
         r#"error[markdown-rel]: non-relative link or image
   |
 5 | <a href="https://example.com/">example</a>
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ used here
   |
 "#
     );
@@ -528,6 +540,7 @@ header: value1
         r#"error[markdown-rel]: non-relative link or image
   |
 5 | <a href="//example.com/">example</a>
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^ used here
   |
 "#
     );
@@ -561,6 +574,7 @@ header: value1
         r#"error[markdown-rel]: non-relative link or image
   |
 5 | <a href="//eips.ethereum.org/EIPS/eip-1234">example</a>
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ used here
   |
   = help: use `./eip-1234.md` instead
 "#
@@ -595,6 +609,7 @@ header: value1
         r#"error[markdown-rel]: non-relative link or image
   |
 5 | <a href="//ercs.ethereum.org/ERCS/erc-1234">example</a>
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ used here
   |
   = help: use `./eip-1234.md` instead
 "#
@@ -655,6 +670,7 @@ header: value1
         r#"error[markdown-rel]: non-relative link or image
   |
 5 | <a href="//creativecommons.org/publicdomain/zero/1.0/">copyright</a>
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ used here
   |
   = help: use `../LICENSE.md` instead
 "#
@@ -715,6 +731,7 @@ header: value1
         r#"error[markdown-rel]: non-relative link or image
   |
 5 | <img src="//example.com/foo.jpg">
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ used here
   |
 "#
     );
@@ -748,6 +765,7 @@ header: value1
         r#"error[markdown-rel]: non-relative link or image
   |
 5 | <img src="//eips.ethereum.org/assets/eip-712/eth_sign.png">
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ used here
   |
   = help: use `../assets/eip-712/eth_sign.png` instead
 "#
@@ -782,6 +800,7 @@ header: value1
         r#"error[markdown-rel]: non-relative link or image
   |
 5 | <img src="//ercs.ethereum.org/assets/erc-712/eth_sign.png">
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ used here
   |
   = help: use `../assets/erc-712/eth_sign.png` instead
 "#
@@ -794,7 +813,7 @@ async fn img_with_scheme_to_eips_ethereum_org() {
 header: value1
 ---
 
-<img src="https://eips.ethereum.org/assets/eip-712/eth_sign.png">
+<img src="https://eips.ethereum.org/assets/eip-712/eth_sign.png">!
 "#;
 
     let reports = Linter::<Text<String>>::default()
@@ -815,7 +834,8 @@ header: value1
         reports,
         r#"error[markdown-rel]: non-relative link or image
   |
-5 | <img src="https://eips.ethereum.org/assets/eip-712/eth_sign.png">
+5 | <img src="https://eips.ethereum.org/assets/eip-712/eth_sign.png">!
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ used here
   |
   = help: use `../assets/eip-712/eth_sign.png` instead
 "#
@@ -850,6 +870,7 @@ header: value1
         r#"error[markdown-rel]: non-relative link or image
   |
 5 | <img src="https://ercs.ethereum.org/assets/erc-712/eth_sign.png">
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ used here
   |
   = help: use `../assets/erc-712/eth_sign.png` instead
 "#

--- a/eipw-lint/tests/lint_markdown_section_order.rs
+++ b/eipw-lint/tests/lint_markdown_section_order.rs
@@ -32,6 +32,7 @@ header: value1
         r#"error[markdown-section-order]: body has extra section(s)
   |
 5 | ## Banana
+  | ^^^^^^^^^
   |
 "#
     );
@@ -64,8 +65,10 @@ header: value1
         r#"error[markdown-section-order]: body has extra section(s)
   |
 5 | ## Foo
+  | ^^^^^^
   |
 9 | ## Bar
+  | ^^^^^^
   |
 "#
     );
@@ -101,6 +104,7 @@ header: value1
         r#"error[markdown-section-order]: section `Banana` is out of order
   |
 5 | ## Banana
+  | ^^^^^^^^^
   |
   = help: `Banana` should come after `Foo`
 "#
@@ -137,6 +141,7 @@ header: value1
         r#"error[markdown-section-order]: section `Banana` is out of order
   |
 5 | ## Banana
+  | ^^^^^^^^^
   |
   = help: `Banana` should come after `Foo`
 "#

--- a/eipw-lint/tests/lint_markdown_spell.rs
+++ b/eipw-lint/tests/lint_markdown_spell.rs
@@ -175,9 +175,12 @@ header: value1
     assert_eq!(
         reports,
         r#"error[markdown-spell]: the word `helloworld` is misspelled
- |
- |
- = warning: could not find a line number for this message
+  |
+4 | /
+5 | | **hello**world
+  | |______________^ somewhere here
+  |
+  = warning: could not find a line number for this message
 "#
     );
 }


### PR DESCRIPTION
This pull request adds support for comrak's source position information, available in versions >= 0.18. There seem to be some bugs in that library, so this is a draft until that's fixed.