### PR TITLE
Fix RUSTSEC-2024-0402

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,9 +637,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2024-0402