### PR TITLE
Fix regular expression for compactability

### DIFF
--- a/eipw-lint/src/lints/markdown/regex.rs
+++ b/eipw-lint/src/lints/markdown/regex.rs
@@ -135,6 +135,10 @@ impl<'a, 'b, 'c> tree::Visitor for ExcludesVisitor<'a, 'b, 'c> {
     }
 
     fn enter_link(&mut self, ast: &Ast, link: &NodeLink) -> Result<Next, Self::Error> {
+        if link.title.is_empty() {
+            println!("Skipping autolink: {}", link.url);
+            return Ok(Next::SkipChildren);
+        }
         self.check(ast, &link.title)
     }
 

--- a/eipw-lint/tests/lint_markdown_regex.rs
+++ b/eipw-lint/tests/lint_markdown_regex.rs
@@ -109,3 +109,35 @@ hello
 "#
     );
 }
+
+#[tokio::test]
+async fn excludes_autolink() {
+    let src = r#"---
+header: value1
+---
+
+A link <https://example.com>.
+Another link [Example](https://example.com).
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "markdown-re",
+            Regex {
+                message: "boop",
+                mode: Mode::Excludes,
+                pattern: "example",
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        reports, 
+        ""
+    );
+}


### PR DESCRIPTION
### Fix
- When logging , found that for autolink the link.title is empty . So, added the condition to skip whenever it is empty.
- Also added a suitable test, with both autolink and Markdown link, to check it prove its proper functionality

Issue Associated #91 