### PR TITLE
fix: detect HTML comments in inline HTML nodes

### DIFF
--- a/eipw-lint/src/lib.rs
+++ b/eipw-lint/src/lib.rs
@@ -565,11 +565,11 @@ impl<'a> SnippetExt<'a> for Snippet<'a> {
 }
 
 trait LevelExt {
-    fn span_utf8(self, text: &str, start: usize, min_len: usize) -> Annotation;
+    fn span_utf8(self, text: &str, start: usize, min_len: usize) -> Annotation<'_>;
 }
 
 impl LevelExt for Level {
-    fn span_utf8(self, text: &str, start: usize, min_len: usize) -> Annotation {
+    fn span_utf8(self, text: &str, start: usize, min_len: usize) -> Annotation<'_> {
         let end = ceil_char_boundary(text, start + min_len);
         self.span(start..end)
     }

--- a/eipw-lint/src/lints/markdown/html_comments.rs
+++ b/eipw-lint/src/lints/markdown/html_comments.rs
@@ -49,6 +49,7 @@ where
             let data = node.data.borrow();
             let fragment = match data.value {
                 NodeValue::HtmlBlock(ref b) => Html::parse_fragment(&b.literal),
+                NodeValue::HtmlInline(ref s) => Html::parse_fragment(s),
                 _ => continue,
             };
 


### PR DESCRIPTION
The HtmlComments lint only checked NodeValue::HtmlBlock but not NodeValue::HtmlInline. This meant inline HTML comments were not detected while block comments were correctly flagged.

This PR adds handling for NodeValue::HtmlInline to ensure all HTML comments are detected regardless of their context.

Changes: Added one line to handle NodeValue::HtmlInline in the match statement

All existing tests pass with this change.