### PR TITLE
fix: detect inline HTML comments in markdown-html-comments lint

### DIFF
--- a/eipw-lint/src/lints/markdown/html_comments.rs
+++ b/eipw-lint/src/lints/markdown/html_comments.rs
@@ -47,9 +47,15 @@ where
 
         for node in ctx.body().descendants() {
             let data = node.data.borrow();
-            let fragment = match data.value {
-                NodeValue::HtmlBlock(ref b) => Html::parse_fragment(&b.literal),
-                _ => continue,
+            let html_content = match data.value {
+                NodeValue::HtmlBlock(ref b) => Some(b.literal.as_str()),
+                NodeValue::HtmlInline(ref s) => Some(s.as_str()),
+                _ => None,
+            };
+
+            let fragment = match html_content {
+                Some(content) => Html::parse_fragment(content),
+                None => continue,
             };
 
             for node in fragment.tree.nodes() {

--- a/eipw-lint/tests/lint_markdown_html_comments.rs
+++ b/eipw-lint/tests/lint_markdown_html_comments.rs
@@ -86,3 +86,76 @@ text after
 "#
     );
 }
+
+#[tokio::test]
+async fn inline_html_comment_error() {
+    let src = r#"---
+header: value2
+---
+hello
+
+This is text with an <!-- inline comment --> in the middle.
+
+text after
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "markdown-html-comments",
+            HtmlComments {
+                name: "header",
+                warn_for: vec!["value1"],
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(
+        reports.contains("error[markdown-html-comments]"),
+        "Expected error for inline HTML comment, got: {}",
+        reports
+    );
+    assert!(
+        reports.contains("inline comment"),
+        "Expected mention of inline comment, got: {}",
+        reports
+    );
+}
+
+#[tokio::test]
+async fn inline_html_comment_warn() {
+    let src = r#"---
+header: value1
+---
+hello
+
+This is text with an <!-- inline comment --> in the middle.
+
+text after
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "markdown-html-comments",
+            HtmlComments {
+                name: "header",
+                warn_for: vec!["value1"],
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(
+        reports.contains("warning[markdown-html-comments]"),
+        "Expected warning for inline HTML comment, got: {}",
+        reports
+    );
+}


### PR DESCRIPTION
Fixes #119

## Problem
The `markdown-html-comments` lint was only checking for `NodeValue::HtmlBlock` but not `NodeValue::HtmlInline`. This meant that inline HTML comments like:

```markdown
text <!-- inline comment --> more text
```

were not being detected and reported, while block-level HTML comments were.

## Solution
Added support for inline HTML comments by also checking `NodeValue::HtmlInline` in addition to `NodeValue::HtmlBlock`.

## Changes
- Modified `html_comments.rs` to handle both HtmlBlock and HtmlInline node types
- Added 2 new test cases:
  - `inline_html_comment_error`: Tests that inline comments are detected as errors
  - `inline_html_comment_warn`: Tests that inline comments are detected as warnings when status is in warn_for list

## Testing
All 4 tests pass:
- `warn` (existing)
- `error` (existing)  
- `inline_html_comment_error` (new)
- `inline_html_comment_warn` (new)