### PR TITLE
fix: skip regex checks on autolink URLs

### DIFF
--- a/eipw-lint/src/lints/markdown/regex.rs
+++ b/eipw-lint/src/lints/markdown/regex.rs
@@ -55,6 +55,7 @@ where
                 message: self.message.as_ref(),
                 pattern,
                 slug,
+                link_stack: Vec::new(),
             },
         };
 
@@ -70,6 +71,7 @@ struct ExcludesVisitor<'a, 'b, 'c> {
     pattern: &'c str,
     slug: &'c str,
     message: &'c str,
+    link_stack: Vec<String>,
 }
 
 impl<'a, 'b, 'c> ExcludesVisitor<'a, 'b, 'c> {
@@ -147,11 +149,20 @@ impl<'a, 'b, 'c> tree::Visitor for ExcludesVisitor<'a, 'b, 'c> {
     }
 
     fn enter_text(&mut self, ast: &Ast, txt: &str) -> Result<Next, Self::Error> {
+        if self.link_stack.last().map(|u| u.as_str()) == Some(txt) {
+            return Ok(Next::TraverseChildren);
+        }
         self.check(ast, txt)
     }
 
     fn enter_link(&mut self, ast: &Ast, link: &NodeLink) -> Result<Next, Self::Error> {
+        self.link_stack.push(link.url.clone());
         self.check(ast, &link.title)
+    }
+
+    fn depart_link(&mut self, _ast: &Ast, _link: &NodeLink) -> Result<(), Self::Error> {
+        self.link_stack.pop();
+        Ok(())
     }
 
     fn enter_image(&mut self, ast: &Ast, link: &NodeLink) -> Result<Next, Self::Error> {

--- a/eipw-lint/tests/lint_markdown_regex_autolinks.rs
+++ b/eipw-lint/tests/lint_markdown_regex_autolinks.rs
@@ -1,0 +1,95 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use eipw_lint::lints::markdown::regex::{Mode, Regex};
+use eipw_lint::reporters::Text;
+use eipw_lint::Linter;
+use pretty_assertions::assert_eq;
+
+#[tokio::test]
+async fn autolink_url_not_checked() {
+    let src = r#"---
+header: value1
+---
+
+A link <https://example.com/eip7002>.
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "markdown-re",
+            Regex {
+                message: "boop",
+                mode: Mode::Excludes,
+                pattern: "eip7002",
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(reports, "");
+}
+
+#[tokio::test]
+async fn regular_link_text_still_checked() {
+    let src = r#"---
+header: value1
+---
+
+A link [eip7002](https://example.com).
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "markdown-re",
+            Regex {
+                message: "boop",
+                mode: Mode::Excludes,
+                pattern: "eip7002",
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(reports.contains("boop"));
+}
+
+#[tokio::test]
+async fn mixed_autolink_and_regular_link() {
+    let src = r#"---
+header: value1
+---
+
+Autolink <https://example.com/eip7002> and [regular](https://example.com).
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "markdown-re",
+            Regex {
+                message: "boop",
+                mode: Mode::Excludes,
+                pattern: "eip7002",
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    // Should be empty because autolink URL is skipped and regular link text doesn't contain "eip7002"
+    assert_eq!(reports, "");
+}


### PR DESCRIPTION
Fixes #91.

Autolinks like \u003chttps://example.com/eip7002\u003e were incorrectly checked against regex patterns, causing false positives when URLs contained prohibited patterns.

## Root Cause

The visitor traverses all text nodes, including autolink URL text, which shouldn't be checked against regex patterns.

## Solution

Use a link URL stack to track when we're inside a link:
1.  pushes the link URL onto the stack
2.  checks if text matches the top URL — if so, it's an autolink and we skip the pattern check
3.  pops the URL from the stack

This correctly handles:
- **Autolinks**: \u003curl\u003e — URL text is not checked
- **Regular links**: [text](url) — link text is still properly checked
- **Nested links**: stack handles nesting correctly

## Changes

- : add stack-based autolink detection
- : regression tests

All existing tests pass.