### PR TITLE
fix: use character count instead of byte length for json_schema annotations

### DIFF
--- a/eipw-lint/src/lints/markdown/json_schema.rs
+++ b/eipw-lint/src/lints/markdown/json_schema.rs
@@ -117,7 +117,7 @@ impl<'a, 'b, 'c> tree::Visitor for Visitor<'a, 'b, 'c> {
         let source = self.ctx.ast_lines(ast);
         let annotations = labels
             .iter()
-            .map(|l| self.ctx.annotation_level().span(0..source.len()).label(l));
+            .map(|l| self.ctx.annotation_level().span(0..source.chars().count()).label(l));
 
         let label = format!(
             "code block of type `{}` does not conform to required schema",

--- a/eipw-lint/tests/eipv/markdown-json-cite-non-ascii/input.md
+++ b/eipw-lint/tests/eipv/markdown-json-cite-non-ascii/input.md
@@ -1,0 +1,55 @@
+---
+eip: 1
+title: A sample proposal
+description: This proposal is a sample that should be considered
+author: John Doe (@johndoe), Jenny Doe <jenny.doe@example.com>
+discussions-to: https://ethereum-magicians.org/t/hello/1
+status: Last Call
+last-call-deadline: 2020-01-01
+type: Standards Track
+category: Core
+created: 2020-01-01
+---
+
+## Abstract
+This is the abstract for the EIP.[^1]
+
+## Motivation
+This is the motivation for the EIP.
+
+## Specification
+This is the specification for the EIP.
+
+## Rationale
+This is the rationale for the EIP.
+
+## Backwards Compatibility
+These are the backwards compatibility concerns for the EIP.
+
+## Test Cases
+These are the test cases for the EIP.
+
+## Reference Implementation
+This is the implementation for the EIP.
+
+## Security Considerations
+These are the security considerations for the EIP.
+
+## Copyright
+Copyright and related rights waived via [CC0](../LICENSE.md).
+
+[^1]:
+    ```csl-json
+    {
+        "type": "article",
+        "id": "1",
+        "author": [
+            {
+                "family": "Mazières",
+                "given": "David"
+            }
+        ],
+        "DOI": "10.1000/182",
+        "URL": "https://example.com"
+    }
+    ```


### PR DESCRIPTION
Fixes panic in `markdown-json-cite` when csl-json blocks contain non-ASCII characters.

The `span()` method expects character indices, but `source.len()` returns byte length. For strings containing multi-byte UTF-8 characters (like `Mazières`), this caused a panic when constructing the annotation.

Changes:
- `eipw-lint/src/lints/markdown/json_schema.rs`: Use `source.chars().count()` instead of `source.len()`
- Added `eipv` test fixture with non-ASCII csl-json content

Closes #100