### PR TITLE
fix: skip regex checks on autolink URLs

### DIFF
--- a/eipw-lint/src/lints/markdown/regex.rs
+++ b/eipw-lint/src/lints/markdown/regex.rs
@@ -55,6 +55,7 @@ where
                 message: self.message.as_ref(),
                 pattern,
                 slug,
+                link_url_stack: Vec::new(),
             },
         };
 
@@ -70,6 +71,9 @@ struct ExcludesVisitor<'a, 'b, 'c> {
     pattern: &'c str,
     slug: &'c str,
     message: &'c str,
+    // Stack of link URLs. When entering a link, push its URL.
+    // When entering text, if text equals the top URL, it's an autolink - skip it.
+    link_url_stack: Vec<String>,
 }
 
 impl<'a, 'b, 'c> ExcludesVisitor<'a, 'b, 'c> {
@@ -147,11 +151,30 @@ impl<'a, 'b, 'c> tree::Visitor for ExcludesVisitor<'a, 'b, 'c> {
     }
 
     fn enter_text(&mut self, ast: &Ast, txt: &str) -> Result<Next, Self::Error> {
+        // Check if this text is inside an autolink by comparing with the parent link URL
+        if let Some(url) = self.link_url_stack.last() {
+            if txt == url {
+                // This is an autolink - the text equals the URL, so skip checking
+                return Ok(Next::TraverseChildren);
+            }
+        }
         self.check(ast, txt)
     }
 
     fn enter_link(&mut self, ast: &Ast, link: &NodeLink) -> Result<Next, Self::Error> {
-        self.check(ast, &link.title)
+        // Push the link URL onto the stack before visiting children
+        self.link_url_stack.push(link.url.clone());
+        
+        // Check the link title (for regular links with explicit title text)
+        self.check(ast, &link.title)?;
+        
+        Ok(Next::TraverseChildren)
+    }
+
+    fn depart_link(&mut self, _ast: &Ast, _link: &NodeLink) -> Result<(), Self::Error> {
+        // Pop the URL from the stack when leaving the link
+        self.link_url_stack.pop();
+        Ok(())
     }
 
     fn enter_image(&mut self, ast: &Ast, link: &NodeLink) -> Result<Next, Self::Error> {

--- a/eipw-lint/tests/lint_markdown_regex_autolinks.rs
+++ b/eipw-lint/tests/lint_markdown_regex_autolinks.rs
@@ -1,0 +1,77 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use eipw_lint::lints::markdown::regex::{Mode, Regex};
+use eipw_lint::reporters::Text;
+use eipw_lint::Linter;
+use pretty_assertions::assert_eq;
+
+#[tokio::test]
+async fn excludes_autolink_text() {
+    let src = r#"---
+header: value1
+---
+
+<https://example.com/eip7002>
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "markdown-re",
+            Regex {
+                message: "boop",
+                mode: Mode::Excludes,
+                pattern: "eip7002",
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    // Autolink URL text should NOT be checked
+    assert_eq!(reports, "");
+}
+
+#[tokio::test]
+async fn excludes_regular_link_text() {
+    let src = r#"---
+header: value1
+---
+
+[eip7002](https://example.com/)
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "markdown-re",
+            Regex {
+                message: "boop",
+                mode: Mode::Excludes,
+                pattern: "eip7002",
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    // Regular link text SHOULD be checked
+    assert_eq!(
+        reports,
+        r#"error[markdown-re]: boop
+  |
+5 | [eip7002](https://example.com/)
+  |  ^^^^^^^
+  |
+  = info: the pattern in question: `eip7002`
+"#
+    );
+}


### PR DESCRIPTION
Fixes #91.

Autolinks like `<https://example.com/eip7002>` have their URL text incorrectly checked against regex patterns, causing false positives when URLs contain prohibited patterns (e.g. `eip7002` matching the `markdown-re-eip-dash` regex).

## Root Cause

The visitor pattern traverses all text nodes, including those inside autolinks. For autolinks, the URL itself becomes the text content and gets checked by `enter_text`, which shouldn't happen.

## Solution

Use a stack-based approach to track link URLs:
1. When entering a link, push its URL onto a stack
2. When entering text, if text equals the top URL, it's an autolink — skip the pattern check
3. When departing a link, pop the URL from the stack

This correctly handles:
- **Autolinks**: `<url>` — URL text is not checked
- **Regular links**: `[text](url)` — link text is still checked
- **Nested links**: Stack handles nesting correctly

## Testing

All existing tests pass, plus new tests verify:
- Autolink URLs don't trigger false positives
- Regular link text is still properly checked