### PR TITLE
fix: fetch_proposals resolves relative to source file, not CWD

### DIFF
--- a/eipw-lint-js/src/lib.rs
+++ b/eipw-lint-js/src/lib.rs
@@ -41,6 +41,12 @@ extern "C" {
     async fn read_file(path: &JsString, encoding: &JsString) -> Result<JsValue, JsValue>;
 }
 
+#[wasm_bindgen(module = "node:process")]
+extern "C" {
+    #[wasm_bindgen(js_name = cwd)]
+    fn process_cwd() -> String;
+}
+
 struct NodeFetch;
 
 impl Fetch for NodeFetch {
@@ -120,7 +126,15 @@ pub async fn lint(sources: Vec<JsValue>, options: Option<Object>) -> Result<JsVa
     let sources: Vec<_> = sources
         .into_iter()
         .map(|v| v.as_string().unwrap())
-        .map(PathBuf::from)
+        .map(|s| {
+            let p = PathBuf::from(&s);
+            if p.is_relative() {
+                let cwd = PathBuf::from(process_cwd());
+                cwd.join(p)
+            } else {
+                p
+            }
+        })
         .collect();
 
     let reporter = Json::default();

--- a/eipw-lint/src/lib.rs
+++ b/eipw-lint/src/lib.rs
@@ -337,6 +337,19 @@ where
                     Source::File(p) => p,
                     _ => unreachable!(),
                 };
+
+                #[cfg(not(target_arch = "wasm32"))]
+                let source_path = if source_path.is_relative() {
+                    std::env::current_dir()
+                        .map(|cwd| cwd.join(source_path))
+                        .unwrap_or_else(|_| source_path.to_path_buf())
+                } else {
+                    source_path.to_path_buf()
+                };
+
+                #[cfg(target_arch = "wasm32")]
+                let source_path = source_path.to_path_buf();
+
                 let source_dir = source_path.parent().unwrap_or_else(|| Path::new("."));
                 let root = match source_path.file_name() {
                     Some(f) if f == "index.md" => source_dir.join(".."),

--- a/eipw-lint/tests/fetch_proposals_cwd.rs
+++ b/eipw-lint/tests/fetch_proposals_cwd.rs
@@ -1,0 +1,100 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use eipw_lint::fetch::Fetch;
+use eipw_lint::reporters::Text;
+use eipw_lint::Linter;
+
+use std::future::Future;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone)]
+struct TrackingFetch {
+    fetched: Arc<Mutex<Vec<PathBuf>>>,
+}
+
+impl Fetch for TrackingFetch {
+    fn fetch(&self, path: PathBuf) -> Pin<Box<dyn Future<Output = Result<String, io::Error>>>> {
+        self.fetched.lock().unwrap().push(path.clone());
+        let fut = async move { tokio::fs::read_to_string(&path).await };
+        Box::pin(fut)
+    }
+}
+
+#[tokio::test]
+async fn fetch_proposals_uses_absolute_paths() -> io::Result<()> {
+    let base = std::env::temp_dir().join(format!("eipw-test-{}", std::process::id()));
+    let eips = base.join("eips");
+    let other = base.join("other");
+
+    tokio::fs::create_dir_all(&eips).await?;
+    tokio::fs::create_dir_all(&other).await?;
+
+    let input = r#"---
+eip: 1234
+title: A sample proposal
+description: A sample description
+author: John Doe (@johndoe)
+discussions-to: https://ethereum-magicians.org/t/hello/1
+status: Draft
+type: Standards Track
+category: Core
+created: 2020-01-01
+requires: 20
+---
+
+## Abstract
+This is the abstract for the EIP.
+"#;
+
+    tokio::fs::write(eips.join("input.md"), input).await?;
+    tokio::fs::write(eips.join("eip-20.md"), "---\nstatus: Draft\n---\n").await?;
+
+    let original_cwd = std::env::current_dir()?;
+    std::env::set_current_dir(&other)?;
+
+    let tracking = TrackingFetch {
+        fetched: Arc::new(Mutex::new(Vec::new())),
+    };
+
+    let result = Linter::<Text<String>>::default()
+        .allow("preamble-file-name")
+        .set_fetch(tracking.clone())
+        .check_file(Path::new("../eips/input.md"))
+        .run()
+        .await;
+
+    std::env::set_current_dir(original_cwd)?;
+
+    // Clean up
+    let _ = tokio::fs::remove_dir_all(&base).await;
+
+    let _reports = result.unwrap().into_inner();
+    let fetched = Arc::try_unwrap(tracking.fetched)
+        .unwrap()
+        .into_inner()
+        .unwrap();
+
+    // Verify that fetch_proposals requested absolute paths,
+    // not relative paths dependent on the working directory.
+    let proposal_path = fetched
+        .iter()
+        .find(|p| p.file_name().map(|f| f == "eip-20.md").unwrap_or(false))
+        .expect("eip-20.md should have been fetched");
+
+    assert!(
+        proposal_path.is_absolute(),
+        "fetch_proposals should use absolute paths, got: {}",
+        proposal_path.display()
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
fix: fetch_proposals resolves relative to source file, not CWD

When  is given a relative source path,  was
constructing relative paths for referenced EIPs. Those paths were
resolved against the process working directory, which fails when the
working directory differs from the source file directory.

This commit makes two changes:

1. In , normalize  paths to absolute
   using  before computing the root directory
   for  (native targets only).

2. In , normalize source paths to absolute
   using  before passing them to , so the
   JS/WASM binding behaves consistently.

A regression test verifies that  requests absolute
paths even when the working directory differs from the source directory.

Closes #12