### PR TITLE
test: add regression tests for unicode input in JSON schema lints

### DIFF
--- a/eipw-lint/tests/eipv/markdown-json-cite-unicode/input.md
+++ b/eipw-lint/tests/eipv/markdown-json-cite-unicode/input.md
@@ -1,0 +1,54 @@
+---
+eip: 1
+title: A sample proposal
+description: This proposal is a sample that should be considered
+author: John Doe (@johndoe), Jenny Doe <jenny.doe@example.com>
+discussions-to: https://ethereum-magicians.org/t/hello/1
+status: Last Call
+last-call-deadline: 2020-01-01
+type: Standards Track
+category: Core
+created: 2020-01-01
+---
+
+## Abstract
+This is the abstract for the EIP.[^1]
+
+## Motivation
+This is the motivation for the EIP.
+
+## Specification
+This is the specification for the EIP.
+
+## Rationale
+This is the rationale for the EIP.
+
+## Backwards Compatibility
+These are the backwards compatibility concerns for the EIP.
+
+## Test Cases
+These are the test cases for the EIP.
+
+## Reference Implementation
+This is the implementation for the EIP.
+
+## Security Considerations
+These are the security considerations for the EIP.
+
+## Copyright
+Copyright and related rights waived via [CC0](../LICENSE.md).
+
+[^1]:
+    ```csl-json
+    {
+        "type": "article",
+        "id": "1",
+        "URL": "https://example.com/article",
+        "DOI": "10.1000/example",
+        "author": [
+            {
+                "family": "Mazières"
+            }
+        ]
+    }
+    ```

--- a/eipw-lint/tests/lint_markdown_json_schema.rs
+++ b/eipw-lint/tests/lint_markdown_json_schema.rs
@@ -264,3 +264,34 @@ header: value1
 
     assert_eq!(reports, "");
 }
+
+#[tokio::test]
+async fn unicode_in_code_block() {
+    let src = r#"---
+header: value1
+---
+
+```hello
+{"family": "Mazières"}
+```
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "markdown-json-schema",
+            JsonSchema {
+                language: "hello",
+                additional_schemas: vec![],
+                schema: r#"{ "type": "object", "required": ["title"], "properties": { "title": { "type": "string" } } }"#,
+                help: "see https://example.com/schema.json",
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    println!("{}", reports);
+}


### PR DESCRIPTION
Adds regression tests covering non-ASCII input in markdown JSON schema lints to prevent regressions of the panic reported in #100.

Changes:
- Add unit test `unicode_in_code_block` to `lint_markdown_json_schema.rs`
- Add eipv fixture `markdown-json-cite-unicode` with unicode author names

Closes #100