### PR TITLE
fix: prevent panic in markdown-json-cite with non-ASCII input

### DIFF
--- a/eipw-lint/src/lints/markdown/json_schema.rs
+++ b/eipw-lint/src/lints/markdown/json_schema.rs
@@ -117,7 +117,7 @@ impl<'a, 'b, 'c> tree::Visitor for Visitor<'a, 'b, 'c> {
         let source = self.ctx.ast_lines(ast);
         let annotations = labels
             .iter()
-            .map(|l| self.ctx.annotation_level().span(0..source.len()).label(l));
+            .map(|l| self.ctx.annotation_level().span(0..source.chars().count()).label(l));
 
         let label = format!(
             "code block of type `{}` does not conform to required schema",

--- a/eipw-lint/tests/eipv/markdown-json-cite-non-ascii/input.md
+++ b/eipw-lint/tests/eipv/markdown-json-cite-non-ascii/input.md
@@ -1,0 +1,55 @@
+---
+eip: 1
+title: A sample proposal
+description: This proposal is a sample that should be considered
+author: John Doe (@johndoe), Jenny Doe <jenny.doe@example.com>
+discussions-to: https://ethereum-magicians.org/t/hello/1
+status: Last Call
+last-call-deadline: 2020-01-01
+type: Standards Track
+category: Core
+created: 2020-01-01
+---
+
+## Abstract
+This is the abstract for the EIP.[^1]
+
+## Motivation
+This is the motivation for the EIP.
+
+## Specification
+This is the specification for the EIP.
+
+## Rationale
+This is the rationale for the EIP.
+
+## Backwards Compatibility
+These are the backwards compatibility concerns for the EIP.
+
+## Test Cases
+These are the test cases for the EIP.
+
+## Reference Implementation
+This is the implementation for the EIP.
+
+## Security Considerations
+These are the security considerations for the EIP.
+
+## Copyright
+Copyright and related rights waived via [CC0](../LICENSE.md).
+
+[^1]:
+    ```csl-json
+    {
+        "type": "article",
+        "id": "1",
+        "author": [
+            {
+                "family": "Mazières",
+                "given": "David"
+            }
+        ],
+        "DOI": "10.1000/182",
+        "URL": "https://example.com"
+    }
+    ```


### PR DESCRIPTION
Fixes #100.

**Bug:** When a CSL-JSON citation block contains non-ASCII characters (e.g., "Mazières"),  panics with:



**Root cause:** In , the annotation span was computed using , which returns the byte length of the UTF-8 string. However,  expects character counts for its ranges. Non-ASCII characters like  take 2 bytes in UTF-8, causing the span end to exceed the source length in characters.

**Fix:** Replace  with  so the span uses character count instead of byte length.

**Testing:**
- Added an  integration test case () that reproduces the exact input from the issue.
- Added unit tests (, , ) to verify the fix prevents the panic and correctly reports the schema validation error.