### PR TITLE
fix: detect HTML comments in inline HTML

### DIFF
--- a/eipw-lint/src/lints/markdown/html_comments.rs
+++ b/eipw-lint/src/lints/markdown/html_comments.rs
@@ -49,6 +49,7 @@ where
             let data = node.data.borrow();
             let fragment = match data.value {
                 NodeValue::HtmlBlock(ref b) => Html::parse_fragment(&b.literal),
+                NodeValue::HtmlInline(ref b) => Html::parse_fragment(b),
                 _ => continue,
             };
 

--- a/eipw-lint/tests/lint_markdown_html_comments.rs
+++ b/eipw-lint/tests/lint_markdown_html_comments.rs
@@ -86,3 +86,71 @@ text after
 "#
     );
 }
+
+#[tokio::test]
+async fn inline_warn() {
+    let src = r#"---
+header: value1
+---
+hello <!-- inline comment --> world
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "markdown-html-comments",
+            HtmlComments {
+                name: "header",
+                warn_for: vec!["value1"],
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        reports,
+        r#"warning[markdown-html-comments]: HTML comments are only allowed while `header` is one of: `value1`
+  |
+4 | hello <!-- inline comment --> world
+  |       -----------------------
+  |
+"#
+    );
+}
+
+#[tokio::test]
+async fn inline_error() {
+    let src = r#"---
+header: value2
+---
+hello <!-- inline comment --> world
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "markdown-html-comments",
+            HtmlComments {
+                name: "header",
+                warn_for: vec!["value1"],
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        reports,
+        r#"error[markdown-html-comments]: HTML comments are not allowed when `header` is `value2`
+  |
+4 | hello <!-- inline comment --> world
+  |       ^^^^^^^^^^^^^^^^^^^^^^^
+  |
+"#
+    );
+}


### PR DESCRIPTION
Fixes #119.

The `markdown-html-comments` lint only checked `HtmlBlock` nodes, missing inline HTML comments like `hello <!-- comment --> world`. This adds `HtmlInline` handling and tests for both warn and error cases.

Changes:
- Added `NodeValue::HtmlInline(ref b) => Html::parse_fragment(b)` to the match in `html_comments.rs`
- Added `inline_warn` and `inline_error` tests to `lint_markdown_html_comments.rs`