### PR TITLE
fix: use char count instead of byte length for json_schema spans

### DIFF
--- a/eipw-lint/src/lints/markdown/json_schema.rs
+++ b/eipw-lint/src/lints/markdown/json_schema.rs
@@ -117,7 +117,7 @@ impl<'a, 'b, 'c> tree::Visitor for Visitor<'a, 'b, 'c> {
         let source = self.ctx.ast_lines(ast);
         let annotations = labels
             .iter()
-            .map(|l| self.ctx.annotation_level().span(0..source.len()).label(l));
+            .map(|l| self.ctx.annotation_level().span(0..source.chars().count()).label(l));
 
         let label = format!(
             "code block of type `{}` does not conform to required schema",

--- a/eipw-lint/tests/lint_markdown_json_schema_non_ascii.rs
+++ b/eipw-lint/tests/lint_markdown_json_schema_non_ascii.rs
@@ -1,0 +1,69 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use eipw_lint::lints::markdown::JsonSchema;
+use eipw_lint::reporters::Text;
+use eipw_lint::Linter;
+use pretty_assertions::assert_eq;
+
+#[tokio::test]
+async fn non_ascii_invalid() {
+    let src = "---\nheader: value1\n---\n\n日本語\n\n```hello\n\"not an integer\"\n```\n";
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "markdown-json-schema",
+            JsonSchema {
+                language: "hello",
+                additional_schemas: vec![],
+                schema: r#"{ "type": "integer" }"#,
+                help: "see https://example.com/schema.json",
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        reports,
+        r#"error[markdown-json-schema]: code block of type `hello` does not conform to required schema
+  |
+7 | / ```hello
+8 | | "not an integer"
+9 | | ```
+  | |___^ "not an integer" is not of type "integer"
+  |
+  = help: see https://example.com/schema.json
+"#
+    );
+}
+
+#[tokio::test]
+async fn non_ascii_valid() {
+    let src = "---\nheader: value1\n---\n\n日本語\n\n```hello\n42\n```\n";
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "markdown-json-schema",
+            JsonSchema {
+                language: "hello",
+                additional_schemas: vec![],
+                schema: r#"{ "type": "integer" }"#,
+                help: "see https://example.com/schema.json",
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(reports, "");
+}


### PR DESCRIPTION
Fixes #100.

The `json_schema` lint was using `source.len()` (byte length) for annotation spans, which causes a panic when the source contains non-ASCII characters (e.g., Unicode in CSL-JSON citations). The `annotate-snippets` crate expects character counts, not byte lengths.

**Changes:**
- Changed `source.len()` to `source.chars().count()` in `json_schema.rs`
- Added test cases for non-ASCII input in CSL-JSON code blocks

**Root cause:** When a code block contains multi-byte UTF-8 characters, `source.len()` returns the byte length (e.g., 99 bytes for 98 characters), but the annotation system expects character indices. This mismatch triggers the panic:
```
SourceAnnotation range `(0, 99)` is bigger than source length `98`
```

All tests pass.