### PR TITLE
fix: use character count for regex lint spans (fixes #100)

### DIFF
--- a/eipw-lint/src/lints/markdown/regex.rs
+++ b/eipw-lint/src/lints/markdown/regex.rs
@@ -87,8 +87,12 @@ impl<'a, 'b, 'c> ExcludesVisitor<'a, 'b, 'c> {
                 .re
                 .find_iter(buf)
                 .map(|m| {
-                    let start = offset + m.start();
-                    let end = offset + m.end();
+                    let byte_start = offset + m.start();
+                    let char_start = source[..byte_start].chars().count();
+                    let start = char_start;
+                    let byte_end = offset + m.end();
+                    let char_end = source[..byte_end].chars().count();
+                    let end = char_end;
                     self.ctx.annotation_level().span(start..end)
                 })
                 .collect(),


### PR DESCRIPTION
**Problem**
The generic `Regex` lint in `eipw-lint/src/lints/markdown/regex.rs` uses byte offsets directly when creating annotation spans. When the source text contains multi-byte UTF-8 characters (e.g., emojis, non-ASCII text), the byte offset exceeds the character count expected by the annotation framework, causing a panic:

```
SourceAnnotation range is bigger than source length
```

This is the same root cause as #100, but affects all markdown lints that use the `Regex` struct (e.g., `markdown-link-first`, `markdown-link-status`, `markdown-rel-links`, etc.), not just `markdown-json-cite`.

**Fix**
Convert byte offsets to character counts using `source[..start].chars().count()` before creating annotation spans, matching how the linting framework expects positions.

**Files changed**
- `eipw-lint/src/lints/markdown/regex.rs`: 6 insertions, 2 deletions

**Verification**
- `cargo test` passes
- The fix follows the same pattern already used in `json_schema.rs` (PRs #162/#164)

Fixes #100