### PR TITLE
Add regression test for non-ASCII input in json_schema lint

### DIFF
--- a/eipw-lint/tests/lint_markdown_json_schema.rs
+++ b/eipw-lint/tests/lint_markdown_json_schema.rs
@@ -264,3 +264,56 @@ header: value1
 
     assert_eq!(reports, "");
 }
+
+// Regression test for https://github.com/ethereum/eipw/issues/100, where a
+// panic would occur reporting a schema violation on a code block containing
+// multi-byte UTF-8 characters.
+#[tokio::test]
+async fn non_ascii_code_block_does_not_panic() {
+    let src = r#"---
+header: value1
+---
+
+```hello
+{"name": "Mazières"}
+```
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "markdown-json-schema",
+            JsonSchema {
+                language: "hello",
+                additional_schemas: vec![],
+                help: "see https://example.com/schema.json",
+                schema: r#"{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Root",
+    "type": "object",
+    "required": ["id"],
+    "properties": {
+        "id": { "type": "string" }
+    }
+}"#,
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        reports,
+        r#"error[markdown-json-schema]: code block of type `hello` does not conform to required schema
+  |
+5 | / ```hello
+6 | | {"name": "Mazières"}
+7 | | ```
+  | |___^ "id" is a required property
+  |
+  = help: see https://example.com/schema.json
+"#
+    );
+}


### PR DESCRIPTION
The repro from #100 no longer panics on current `master` (likely fixed as part of the `annotate-snippets` 0.11 upgrade), but there is no test covering non-ASCII content in a code block validated by `markdown-json-schema`. This adds one.

I confirmed against current `master`:

- Reproduced the original `[^1]`/`csl-json`/`Mazières` document — it prints schema errors cleanly, no panic.
- Added a more minimal test that triggers a schema violation on a code block containing `Mazières` and asserts the rendered output, so a future regression in the byte-vs-char indexing in the snippet reporter would fail this test rather than crashing.

`cargo test --test lint_markdown_json_schema` passes (7/7), `cargo fmt --check` clean. Happy to close #100 if that matches your preference, or leave the issue open if you'd rather verify separately first.