### PR TITLE
Add markdown-solidity-license lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ error[preamble-order]: preamble header `description` must come after `title`
 | `markdown-link-status`              | EIPs linked in the body have statuses further along than the current proposal.                |
 | `markdown-no-backticks`             | No proposals are referenced inside backticks (eg. \`EIP-1234\`).                              |
 | `markdown-no-smart-quotes`          | Smart quotes (", ", ', ') are not allowed, use straight quotes (", ') instead.                |
+| `markdown-solidity-license`         | Solidity code blocks that declare an SPDX license must use `CC0-1.0`.                         |
 | `markdown-order-section`            | There are no extra sections and the sections are in the correct order.                        |
 | `markdown-re-eip-dash`              | Other EIPs are referenced using EIP-X, not EIPX or EIP X.                                     |
 | `markdown-re-erc-dash`              | Other ERCs are referenced using ERC-X, not ERCX or ERC X.                                     |

--- a/docs/markdown-solidity-license/index.html
+++ b/docs/markdown-solidity-license/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<title>markdown-solidity-license</title>
+		<link rel="stylesheet" href="../main.css">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+	</head>
+	<body>
+		<article>
+			<h1><code>markdown-solidity-license</code></h1>
+			<p>
+				Inline Solidity code blocks that declare a
+				<code>SPDX-License-Identifier</code> must use
+				<code>CC0-1.0</code>.
+			</p>
+
+			<section>
+				<h2>Examples</h2>
+
+				<pre>error[markdown-solidity-license]: code block of type `solidity` must use license `CC0-1.0`, not `MIT`
+ --> input.md
+  |
+5 | / ```solidity
+6 | | // SPDX-License-Identifier: MIT
+7 | | interface FooToken {}
+8 | | ```
+  | |___^
+  |</pre>
+			</section>
+			<section>
+				<h2>Explanation</h2>
+
+				<p>
+					Per
+					<a href="https://eips.ethereum.org/EIPS/eip-1">EIP-1</a>,
+					proposals are licensed under
+					<code>CC0-1.0</code>. Solidity snippets included inside
+					an EIP are part of the proposal and must carry the same
+					license when they declare one.
+				</p>
+				<p>
+					Code blocks without a
+					<code>SPDX-License-Identifier</code> line are not
+					flagged: the lint only reports blocks that explicitly
+					pick a license other than the expected one.
+				</p>
+			</section>
+		</article>
+	</body>
+</html>

--- a/eipw-lint/src/config.rs
+++ b/eipw-lint/src/config.rs
@@ -94,6 +94,13 @@ fn default_lints() -> impl Iterator<Item = (&'static str, DefaultLint<&'static s
             }),
         ),
         (
+            "markdown-solidity-license",
+            MarkdownCodeBlockLicense(markdown::CodeBlockLicense {
+                language: "solidity",
+                license: "CC0-1.0",
+            }),
+        ),
+        (
             "preamble-re-description-erc-dash",
             PreambleRegex(preamble::Regex {
                 name: "description",

--- a/eipw-lint/src/lints/known_lints.rs
+++ b/eipw-lint/src/lints/known_lints.rs
@@ -52,6 +52,7 @@ pub enum DefaultLint<S> {
         name: preamble::Url<S>,
     },
 
+    MarkdownCodeBlockLicense(markdown::CodeBlockLicense<S>),
     MarkdownHtmlComments(markdown::HtmlComments<S>),
     MarkdownJsonSchema(markdown::JsonSchema<S>),
     MarkdownLinkFirst {
@@ -100,6 +101,7 @@ where
             Self::PreambleUintList { name } => name,
             Self::PreambleUrl { name } => name,
 
+            Self::MarkdownCodeBlockLicense(l) => l,
             Self::MarkdownHtmlComments(l) => l,
             Self::MarkdownJsonSchema(l) => l,
             Self::MarkdownLinkFirst { pattern } => pattern,
@@ -200,6 +202,12 @@ where
                 name: preamble::Url(name.0.as_ref()),
             },
 
+            Self::MarkdownCodeBlockLicense(l) => {
+                DefaultLint::MarkdownCodeBlockLicense(markdown::CodeBlockLicense {
+                    language: l.language.as_ref(),
+                    license: l.license.as_ref(),
+                })
+            }
             Self::MarkdownHtmlComments(l) => {
                 DefaultLint::MarkdownHtmlComments(markdown::HtmlComments {
                     name: l.name.as_ref(),
@@ -352,6 +360,12 @@ impl From<DefaultLint<&str>> for DefaultLint<String> {
                 name: preamble::Url(name.0.to_string()),
             },
 
+            DefaultLint::MarkdownCodeBlockLicense(l) => {
+                DefaultLint::MarkdownCodeBlockLicense(markdown::CodeBlockLicense {
+                    language: l.language.to_string(),
+                    license: l.license.to_string(),
+                })
+            }
             DefaultLint::MarkdownHtmlComments(l) => {
                 DefaultLint::MarkdownHtmlComments(markdown::HtmlComments {
                     name: l.name.to_string(),

--- a/eipw-lint/src/lints/markdown.rs
+++ b/eipw-lint/src/lints/markdown.rs
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+pub mod code_block_license;
 pub mod heading_first;
 pub mod headings_space;
 pub mod html_comments;
@@ -18,6 +19,7 @@ pub mod section_order;
 pub mod section_required;
 pub mod spell;
 
+pub use self::code_block_license::CodeBlockLicense;
 pub use self::heading_first::HeadingFirst;
 pub use self::headings_space::HeadingsSpace;
 pub use self::html_comments::HtmlComments;

--- a/eipw-lint/src/lints/markdown/code_block_license.rs
+++ b/eipw-lint/src/lints/markdown/code_block_license.rs
@@ -1,0 +1,104 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use eipw_snippets::Snippet;
+
+use comrak::nodes::{Ast, NodeCodeBlock};
+
+use crate::lints::{Context, Error, Lint};
+use crate::tree::{self, Next, TraverseExt};
+use crate::SnippetExt;
+
+use ::regex::Regex as TextRegex;
+
+use serde::{Deserialize, Serialize};
+
+use std::fmt::{Debug, Display};
+use std::sync::OnceLock;
+
+fn spdx_regex() -> &'static TextRegex {
+    static RE: OnceLock<TextRegex> = OnceLock::new();
+    RE.get_or_init(|| {
+        TextRegex::new(
+            r"(?m)^\s*(?://|#|/\*+|\*)\s*SPDX-License-Identifier\s*:\s*(.+?)\s*(?:\*/)?\s*$",
+        )
+        .expect("hard-coded SPDX regex should be valid")
+    })
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema-version", derive(schemars::JsonSchema))]
+pub struct CodeBlockLicense<S> {
+    pub language: S,
+    pub license: S,
+}
+
+impl<S> Lint for CodeBlockLicense<S>
+where
+    S: Debug + Display + AsRef<str>,
+{
+    fn lint<'a>(&self, slug: &'a str, ctx: &Context<'a, '_>) -> Result<(), Error> {
+        let mut visitor = Visitor {
+            ctx,
+            slug,
+            language: self.language.as_ref(),
+            license: self.license.as_ref(),
+        };
+
+        ctx.body().traverse().visit(&mut visitor)?;
+
+        Ok(())
+    }
+}
+
+struct Visitor<'a, 'b, 'c> {
+    ctx: &'c Context<'a, 'b>,
+    slug: &'c str,
+    language: &'c str,
+    license: &'c str,
+}
+
+impl<'a, 'b, 'c> tree::Visitor for Visitor<'a, 'b, 'c> {
+    type Error = Error;
+
+    fn enter_code_block(&mut self, ast: &Ast, node: &NodeCodeBlock) -> Result<Next, Self::Error> {
+        let info = node.info.split_whitespace().next().unwrap_or("");
+        if info != self.language {
+            return Ok(Next::SkipChildren);
+        }
+
+        let captures = match spdx_regex().captures(&node.literal) {
+            Some(c) => c,
+            None => return Ok(Next::SkipChildren),
+        };
+
+        let actual = captures.get(1).unwrap().as_str();
+        if actual == self.license {
+            return Ok(Next::SkipChildren);
+        }
+
+        let label = format!(
+            "code block of type `{}` must use license `{}`, not `{}`",
+            self.language, self.license, actual,
+        );
+        let source = self.ctx.ast_lines(ast);
+        self.ctx.report(
+            self.ctx
+                .annotation_level()
+                .title(&label)
+                .id(self.slug)
+                .snippet(
+                    Snippet::source(source)
+                        .fold(true)
+                        .line_start(ast.sourcepos.start.line)
+                        .origin_opt(self.ctx.origin())
+                        .annotation(self.ctx.annotation_level().span(0..source.len())),
+                ),
+        )?;
+
+        Ok(Next::SkipChildren)
+    }
+}

--- a/eipw-lint/tests/lint_markdown_code_block_license.rs
+++ b/eipw-lint/tests/lint_markdown_code_block_license.rs
@@ -1,0 +1,204 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use eipw_lint::lints::markdown::CodeBlockLicense;
+use eipw_lint::reporters::Text;
+use eipw_lint::Linter;
+use pretty_assertions::assert_eq;
+
+#[tokio::test]
+async fn wrong_license() {
+    let src = r#"---
+header: value1
+---
+
+```solidity
+// SPDX-License-Identifier: MIT
+
+interface FooToken {}
+```
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "markdown-solidity-license",
+            CodeBlockLicense {
+                language: "solidity",
+                license: "CC0-1.0",
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        reports,
+        r#"error[markdown-solidity-license]: code block of type `solidity` must use license `CC0-1.0`, not `MIT`
+  |
+5 | / ```solidity
+6 | | // SPDX-License-Identifier: MIT
+7 | |
+8 | | interface FooToken {}
+9 | | ```
+  | |___^
+  |
+"#
+    );
+}
+
+#[tokio::test]
+async fn correct_license() {
+    let src = r#"---
+header: value1
+---
+
+```solidity
+// SPDX-License-Identifier: CC0-1.0
+
+interface FooToken {}
+```
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "markdown-solidity-license",
+            CodeBlockLicense {
+                language: "solidity",
+                license: "CC0-1.0",
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(reports, "");
+}
+
+#[tokio::test]
+async fn no_spdx_header() {
+    let src = r#"---
+header: value1
+---
+
+```solidity
+interface FooToken {}
+```
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "markdown-solidity-license",
+            CodeBlockLicense {
+                language: "solidity",
+                license: "CC0-1.0",
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(reports, "");
+}
+
+#[tokio::test]
+async fn different_language_is_ignored() {
+    let src = r#"---
+header: value1
+---
+
+```rust
+// SPDX-License-Identifier: MIT
+fn main() {}
+```
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "markdown-solidity-license",
+            CodeBlockLicense {
+                language: "solidity",
+                license: "CC0-1.0",
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(reports, "");
+}
+
+#[tokio::test]
+async fn block_comment_spdx() {
+    let src = r#"---
+header: value1
+---
+
+```solidity
+/* SPDX-License-Identifier: MIT */
+interface FooToken {}
+```
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "markdown-solidity-license",
+            CodeBlockLicense {
+                language: "solidity",
+                license: "CC0-1.0",
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(reports.contains("must use license `CC0-1.0`, not `MIT`"));
+}
+
+#[tokio::test]
+async fn language_with_info_string_attrs() {
+    // Some markdown renderers allow extra info on the fence, e.g. ``` solidity {.foo}
+    let src = "---
+header: value1
+---
+
+```solidity {.line-numbers}
+// SPDX-License-Identifier: MIT
+interface FooToken {}
+```
+";
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "markdown-solidity-license",
+            CodeBlockLicense {
+                language: "solidity",
+                license: "CC0-1.0",
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(reports.contains("must use license `CC0-1.0`, not `MIT`"));
+}


### PR DESCRIPTION
Closes #11.

Adds a new `markdown-solidity-license` lint that flags Solidity code blocks
inside an EIP whose `SPDX-License-Identifier` is not the expected
`CC0-1.0`. Blocks without an SPDX line aren't reported — only ones that
explicitly pick a license other than the configured one. Other languages
are skipped.

Configurable via `language` and `license`; the default lint set is
registered as `language: "solidity"`, `license: "CC0-1.0"`, matching the
license requirement from EIP-1.

## Test plan

- [x] `cargo test -p eipw-lint --test lint_markdown_code_block_license` (6 tests)
- [x] `cargo test -p eipw-lint` (full suite green)
- [x] `cargo fmt --check -p eipw-lint`
- [x] `cargo clippy -p eipw-lint --tests` (no new warnings)