### PR TITLE
fix: report inline HTML comments

### DIFF
--- a/eipw-lint/src/lints/markdown/html_comments.rs
+++ b/eipw-lint/src/lints/markdown/html_comments.rs
@@ -49,6 +49,7 @@ where
             let data = node.data.borrow();
             let fragment = match data.value {
                 NodeValue::HtmlBlock(ref b) => Html::parse_fragment(&b.literal),
+                NodeValue::HtmlInline(ref s) => Html::parse_fragment(s),
                 _ => continue,
             };
 

--- a/eipw-lint/tests/eipv/markdown-html-comments/expected.txt
+++ b/eipw-lint/tests/eipv/markdown-html-comments/expected.txt
@@ -4,3 +4,8 @@ error[markdown-html-comments]: HTML comments are not allowed when `status` is `L
 16 | <!-- This is an html comment -->
    | ^^
    |
+  ::: input.md:19:13
+   |
+19 | This is the <!-- motivation -->.
+   |             ^^^^^^^^^^^^^^^^^^^
+   |

--- a/eipw-lint/tests/lint_markdown_html_comments.rs
+++ b/eipw-lint/tests/lint_markdown_html_comments.rs
@@ -86,3 +86,37 @@ text after
 "#
     );
 }
+
+#[tokio::test]
+async fn inline_error() {
+    let src = r#"---
+header: value2
+---
+hello <!-- inline --> text
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "markdown-html-comments",
+            HtmlComments {
+                name: "header",
+                warn_for: vec!["value1"],
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        reports,
+        r#"error[markdown-html-comments]: HTML comments are not allowed when `header` is `value2`
+  |
+4 | hello <!-- inline --> text
+  |       ^^^^^^^^^^^^^^^
+  |
+"#
+    );
+}


### PR DESCRIPTION
## Summary
- make `markdown-html-comments` inspect `NodeValue::HtmlInline` in addition to `HtmlBlock`
- add unit coverage for inline HTML comment diagnostics
- update the eipv `markdown-html-comments` fixture so the previously missed inline comment is reported

Fixes #119

## Validation
- `cargo fmt --check`
- `cargo test -p eipw-lint --test lint_markdown_html_comments`
- `cargo test -p eipw-lint --features tokio --test eipv`
- `cargo test -p eipw-lint --features tokio`
- `git diff --check`

## Note
I also tried `cargo clippy -p eipw-lint --all-targets -- -D warnings`, but it currently fails on pre-existing lints outside this change (`type_complexity`, `result_large_err`, `useless_conversion`, `unneeded_struct_pattern`, and `filter_next`). I left those out of scope for this focused bug fix.