### PR TITLE
Allow network-upgrade preamble marker

### DIFF
--- a/eipw-lint/src/config.rs
+++ b/eipw-lint/src/config.rs
@@ -173,6 +173,15 @@ fn default_lints() -> impl Iterator<Item = (&'static str, DefaultLint<&'static s
             ),
         ),
         (
+            "preamble-len-network-upgrade",
+            PreambleLength(preamble::Length {
+                name: "network-upgrade",
+                min: Some(1),
+                max: None,
+            }
+            ),
+        ),
+        (
             "preamble-req",
             PreambleRequired { names: preamble::Required(vec![
                 "eip",
@@ -198,6 +207,7 @@ fn default_lints() -> impl Iterator<Item = (&'static str, DefaultLint<&'static s
                 "last-call-deadline",
                 "type",
                 "category",
+                "network-upgrade",
                 "created",
                 "requires",
                 "withdrawal-reason",
@@ -224,6 +234,15 @@ fn default_lints() -> impl Iterator<Item = (&'static str, DefaultLint<&'static s
                 when: "type",
                 equals: "Standards Track",
                 then: "category",
+            }
+            ),
+        ),
+        (
+            "preamble-allowed-network-upgrade",
+            PreambleAllowedOnlyIfEq(preamble::AllowedOnlyIfEq {
+                when: "type",
+                equals: "Meta",
+                then: "network-upgrade",
             }
             ),
         ),

--- a/eipw-lint/src/lints/known_lints.rs
+++ b/eipw-lint/src/lints/known_lints.rs
@@ -17,6 +17,7 @@ use super::{markdown, preamble, Lint};
 #[serde(tag = "kind", rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum DefaultLint<S> {
+    PreambleAllowedOnlyIfEq(preamble::AllowedOnlyIfEq<S>),
     PreambleAuthor {
         name: preamble::Author<S>,
     },
@@ -81,6 +82,7 @@ where
 {
     pub(crate) fn as_inner(&self) -> &dyn Lint {
         match self {
+            Self::PreambleAllowedOnlyIfEq(l) => l,
             Self::PreambleAuthor { name } => name,
             Self::PreambleDate { name } => name,
             Self::PreambleFileName(l) => l,
@@ -123,6 +125,13 @@ where
 {
     pub(crate) fn map_to_str(&self) -> DefaultLint<&str> {
         match self {
+            Self::PreambleAllowedOnlyIfEq(l) => {
+                DefaultLint::PreambleAllowedOnlyIfEq(preamble::AllowedOnlyIfEq {
+                    equals: l.equals.as_ref(),
+                    then: l.then.as_ref(),
+                    when: l.when.as_ref(),
+                })
+            }
             Self::PreambleAuthor { name } => DefaultLint::PreambleAuthor {
                 name: preamble::Author(name.0.as_ref()),
             },
@@ -275,6 +284,13 @@ where
 impl From<DefaultLint<&str>> for DefaultLint<String> {
     fn from(value: DefaultLint<&str>) -> Self {
         match value {
+            DefaultLint::PreambleAllowedOnlyIfEq(l) => {
+                DefaultLint::PreambleAllowedOnlyIfEq(preamble::AllowedOnlyIfEq {
+                    equals: l.equals.to_string(),
+                    then: l.then.to_string(),
+                    when: l.when.to_string(),
+                })
+            }
             DefaultLint::PreambleAuthor { name } => DefaultLint::PreambleAuthor {
                 name: preamble::Author(name.0.to_string()),
             },

--- a/eipw-lint/src/lints/preamble.rs
+++ b/eipw-lint/src/lints/preamble.rs
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+pub mod allowed_only_if_eq;
 pub mod author;
 pub mod date;
 pub mod file_name;
@@ -22,6 +23,7 @@ pub mod trim;
 pub mod uint;
 pub mod url;
 
+pub use self::allowed_only_if_eq::AllowedOnlyIfEq;
 pub use self::author::Author;
 pub use self::date::Date;
 pub use self::file_name::FileName;

--- a/eipw-lint/src/lints/preamble/allowed_only_if_eq.rs
+++ b/eipw-lint/src/lints/preamble/allowed_only_if_eq.rs
@@ -1,0 +1,107 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use eipw_snippets::{Level, Snippet};
+
+use crate::{
+    lints::{Context, Error, Lint},
+    SnippetExt,
+};
+
+use serde::{Deserialize, Serialize};
+
+use std::fmt::{Debug, Display};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema-version", derive(schemars::JsonSchema))]
+pub struct AllowedOnlyIfEq<S> {
+    pub when: S,
+    pub equals: S,
+    pub then: S,
+}
+
+impl<S> Lint for AllowedOnlyIfEq<S>
+where
+    S: Debug + Display + AsRef<str>,
+{
+    fn lint<'a>(&self, slug: &'a str, ctx: &Context<'a, '_>) -> Result<(), Error> {
+        let then_opt = ctx.preamble().by_name(self.then.as_ref());
+        let when_opt = ctx.preamble().by_name(self.when.as_ref());
+
+        let Some(then) = then_opt else {
+            return Ok(());
+        };
+
+        let equals = self.equals.as_ref();
+
+        match when_opt {
+            Some(when) if when.value().trim() == equals => {}
+            Some(when) => {
+                let label = format!(
+                    "preamble header `{}` is only allowed when `{}` is `{}`",
+                    self.then, self.when, self.equals,
+                );
+                let info_label = format!("unless equal to `{}`", self.equals);
+
+                let mut slices = vec![
+                    (
+                        when.line_start(),
+                        Snippet::source(when.source())
+                            .line_start(when.line_start())
+                            .fold(false)
+                            .origin_opt(ctx.origin())
+                            .annotation(
+                                Level::Info.span(0..when.source().len()).label(&info_label),
+                            ),
+                    ),
+                    (
+                        then.line_start(),
+                        Snippet::source(then.source())
+                            .line_start(then.line_start())
+                            .fold(false)
+                            .origin_opt(ctx.origin())
+                            .annotation(
+                                ctx.annotation_level()
+                                    .span(0..then.source().len())
+                                    .label("remove this"),
+                            ),
+                    ),
+                ];
+
+                slices.sort_by_key(|(line_start, _)| *line_start);
+
+                ctx.report(
+                    ctx.annotation_level()
+                        .title(&label)
+                        .id(slug)
+                        .snippets(slices.into_iter().map(|(_, s)| s)),
+                )?;
+            }
+            None => {
+                let label = format!(
+                    "preamble header `{}` is only allowed when `{}` is `{}`",
+                    self.then, self.when, self.equals,
+                );
+
+                ctx.report(
+                    ctx.annotation_level().title(&label).id(slug).snippet(
+                        Snippet::source(then.source())
+                            .fold(false)
+                            .origin_opt(ctx.origin())
+                            .line_start(then.line_start())
+                            .annotation(
+                                ctx.annotation_level()
+                                    .span(0..then.source().len())
+                                    .label("defined here"),
+                            ),
+                    ),
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/eipw-lint/tests/lint_preamble_allowed_only_if_eq.rs
+++ b/eipw-lint/tests/lint_preamble_allowed_only_if_eq.rs
@@ -1,0 +1,113 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use eipw_lint::lints::preamble::AllowedOnlyIfEq;
+use eipw_lint::reporters::Text;
+use eipw_lint::Linter;
+use pretty_assertions::assert_eq;
+
+async fn reports_for(src: &str) -> String {
+    Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny(
+            "allowed-only-if-eq",
+            AllowedOnlyIfEq {
+                when: "mode",
+                equals: "advanced",
+                then: "advanced-setting",
+            },
+        )
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner()
+}
+
+#[tokio::test]
+async fn without_when_or_then() {
+    let src = r#"---
+header: value1
+---
+hello world"#;
+
+    assert_eq!(reports_for(src).await, "");
+}
+
+#[tokio::test]
+async fn when_equal_without_then() {
+    let src = r#"---
+mode: advanced
+header: value1
+---
+hello world"#;
+
+    assert_eq!(reports_for(src).await, "");
+}
+
+#[tokio::test]
+async fn when_equal_with_then() {
+    let src = r#"---
+mode: advanced
+advanced-setting: enabled
+---
+hello world"#;
+
+    assert_eq!(reports_for(src).await, "");
+}
+
+#[tokio::test]
+async fn when_not_equal_without_then() {
+    let src = r#"---
+mode: basic
+header: value1
+---
+hello world"#;
+
+    assert_eq!(reports_for(src).await, "");
+}
+
+#[tokio::test]
+async fn without_when_with_then() {
+    let src = r#"---
+header: value1
+advanced-setting: enabled
+---
+hello world"#;
+
+    assert_eq!(
+        reports_for(src).await,
+        r#"error[allowed-only-if-eq]: preamble header `advanced-setting` is only allowed when `mode` is `advanced`
+  |
+3 | advanced-setting: enabled
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^ defined here
+  |
+"#
+    );
+}
+
+#[tokio::test]
+async fn when_not_equal_with_then() {
+    let src = r#"---
+mode: basic
+header: value1
+advanced-setting: enabled
+---
+hello world"#;
+
+    assert_eq!(
+        reports_for(src).await,
+        r#"error[allowed-only-if-eq]: preamble header `advanced-setting` is only allowed when `mode` is `advanced`
+  |
+2 | mode: basic
+  | ----------- info: unless equal to `advanced`
+  |
+4 | advanced-setting: enabled
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^ remove this
+  |
+"#
+    );
+}

--- a/eipw-lint/tests/lint_preamble_network_upgrade.rs
+++ b/eipw-lint/tests/lint_preamble_network_upgrade.rs
@@ -1,0 +1,100 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use eipw_lint::reporters::Text;
+use eipw_lint::Linter;
+
+fn proposal(proposal_type: &str, category: Option<&str>, network_upgrade: Option<&str>) -> String {
+    let category = category
+        .map(|category| format!("category: {category}\n"))
+        .unwrap_or_default();
+    let network_upgrade = network_upgrade
+        .map(|network_upgrade| format!("network-upgrade: {network_upgrade}\n"))
+        .unwrap_or_default();
+
+    format!(
+        r#"---
+eip: 1
+title: Example proposal
+description: Example description
+author: John Doe (@johndoe)
+discussions-to: https://ethereum-magicians.org/t/hello/1
+status: Draft
+type: {proposal_type}
+{category}{network_upgrade}created: 2020-01-01
+---
+
+## Abstract
+This is the abstract for the proposal.
+
+## Specification
+This is the specification for the proposal.
+
+## Rationale
+This is the rationale for the proposal.
+
+## Security Considerations
+These are the security considerations for the proposal.
+
+## Copyright
+Copyright and related rights waived via [CC0](../LICENSE.md).
+"#
+    )
+}
+
+async fn reports_for(src: &str) -> String {
+    Linter::<Text<String>>::default()
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner()
+}
+
+#[tokio::test]
+async fn network_upgrade_is_accepted_on_meta() {
+    let src = proposal("Meta", None, Some("Glamsterdam"));
+
+    assert_eq!(reports_for(&src).await, "");
+}
+
+#[tokio::test]
+async fn network_upgrade_is_optional_on_meta() {
+    let src = proposal("Meta", None, None);
+
+    assert_eq!(reports_for(&src).await, "");
+}
+
+#[tokio::test]
+async fn network_upgrade_is_rejected_on_standards_track() {
+    let src = proposal("Standards Track", Some("Core"), Some("Glamsterdam"));
+    let reports = reports_for(&src).await;
+
+    assert!(
+        reports.contains("preamble header `network-upgrade` is only allowed when `type` is `Meta`")
+    );
+    assert!(!reports.contains("preamble has extra header"));
+}
+
+#[tokio::test]
+async fn network_upgrade_is_rejected_on_informational() {
+    let src = proposal("Informational", None, Some("Glamsterdam"));
+    let reports = reports_for(&src).await;
+
+    assert!(
+        reports.contains("preamble header `network-upgrade` is only allowed when `type` is `Meta`")
+    );
+    assert!(!reports.contains("preamble has extra header"));
+}
+
+#[tokio::test]
+async fn empty_network_upgrade_is_rejected() {
+    let src = proposal("Meta", None, Some(""));
+    let reports = reports_for(&src).await;
+
+    assert!(reports.contains("preamble header `network-upgrade` value is too short (min 1)"));
+    assert!(!reports.contains("preamble has extra header"));
+}


### PR DESCRIPTION
## Summary

This PR adds lint support for the `network-upgrade` preamble field so Meta EIPs can mark the hardfork/network upgrade they describe.

The field is optional on Meta EIPs, rejected on non-Meta proposals, and rejected when present but empty.

This is part of the hardfork/network-upgrade rollout tracked in https://github.com/eips-wg/preprocessor/issues/35. The eips-wg site preprocessor consumes this marker to generate a hardfork index and proposal-page membership metadata.

## Example

A Meta EIP can now include:

```yaml
---
eip: 9999
type: Meta
network-upgrade: Glamsterdam
...
---
```

## Changes

- Add `network-upgrade` to the default preamble order between `category` and `created`.
- Reject empty `network-upgrade` values through the existing length lint.
- Add a generic `AllowedOnlyIfEq` preamble lint for fields that are allowed only when another field has a configured value.
- Configure `network-upgrade` to be allowed only when `type: Meta`.
- Add tests for the generic lint and default `network-upgrade` behavior.

## Notes

`AllowedOnlyIfEq` mirrors the existing `RequiredIfEq` lint with inverted semantics: where `RequiredIfEq` requires a field when another equals a value, `AllowedOnlyIfEq` forbids a field unless another equals a value.

This PR only teaches eipw to accept and validate the new marker. It does not add `network-upgrade` markers to EIPs or require the marker on all Meta EIPs.