### PR TITLE
Add RFC first-reference link lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ error[preamble-order]: preamble header `description` must come after `title`
 | `markdown-html-comments`            | There are no HTML comments in review-ready EIPs                                               |
 | `markdown-json-cite`                | All `csl-json` code blocks adhere to the correct schema.                                      |
 | `markdown-link-first`               | First mention of an EIP must be a link.                                                       |
+| `markdown-link-first-rfc`           | First mention of each RFC must be a link.                                                      |
 | `markdown-link-status`              | EIPs linked in the body have statuses further along than the current proposal.                |
 | `markdown-no-backticks`             | No proposals are referenced inside backticks (eg. \`EIP-1234\`).                              |
 | `markdown-no-smart-quotes`          | Smart quotes (", ", ', ') are not allowed, use straight quotes (", ') instead.                |

--- a/eipw-lint/src/config.rs
+++ b/eipw-lint/src/config.rs
@@ -380,6 +380,10 @@ fn default_lints() -> impl Iterator<Item = (&'static str, DefaultLint<&'static s
         (
             "markdown-link-first-rfc",
             MarkdownLinkFirst {
+                // HACK: Capture the RFC prefix rather than the numeric identifier. `LinkFirst`
+                //       uses capture group 1 to exempt an EIP's own number; keeping that group
+                //       non-numeric prevents an EIP whose number happens to equal an RFC number
+                //       from accidentally skipping the RFC check.
                 pattern: markdown::LinkFirst(r"(?i)(rfc)\s+[0-9]+"),
             }
         ),

--- a/eipw-lint/src/config.rs
+++ b/eipw-lint/src/config.rs
@@ -378,6 +378,12 @@ fn default_lints() -> impl Iterator<Item = (&'static str, DefaultLint<&'static s
             }
         ),
         (
+            "markdown-link-first-rfc",
+            MarkdownLinkFirst {
+                pattern: markdown::LinkFirst(r"(?i)(rfc)\s+[0-9]+"),
+            }
+        ),
+        (
             "markdown-no-backticks",
             MarkdownNoBackticks {
                 pattern: markdown::NoBackticks(r"(?i)(eip|erc)-[0-9]+"),

--- a/eipw-lint/tests/lint_markdown_link_first.rs
+++ b/eipw-lint/tests/lint_markdown_link_first.rs
@@ -9,6 +9,8 @@ use eipw_lint::reporters::Text;
 use eipw_lint::Linter;
 use pretty_assertions::assert_eq;
 
+const RFC_PATTERN: &str = r"(?i)(rfc)\s+[0-9]+";
+
 #[tokio::test]
 async fn unlinked_then_linked_with_header() {
     let src = r#"---
@@ -139,4 +141,88 @@ EIP-1234
         .into_inner();
 
     assert_eq!(reports, "");
+}
+
+#[tokio::test]
+async fn rfc_unlinked_then_linked() {
+    let src = r#"---
+eip: 4444
+---
+RFC 2119
+
+[RFC 2119](https://www.rfc-editor.org/rfc/rfc2119)
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny("markdown-link-first-rfc", LinkFirst(RFC_PATTERN))
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        reports,
+        r#"error[markdown-link-first-rfc]: the first match of the given pattern must be a link
+  |
+4 | RFC 2119
+  | ^^^^^^^^
+  |
+  = info: the pattern in question: `(?i)(rfc)\s+[0-9]+`
+"#
+    );
+}
+
+#[tokio::test]
+async fn rfc_linked_then_unlinked() {
+    let src = r#"---
+eip: 4444
+---
+[RFC 2119](https://www.rfc-editor.org/rfc/rfc2119)
+
+RFC 2119
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny("markdown-link-first-rfc", LinkFirst(RFC_PATTERN))
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(reports, "");
+}
+
+#[tokio::test]
+async fn rfc_each_number_requires_its_own_link() {
+    let src = r#"---
+eip: 4444
+---
+[RFC 2119](https://www.rfc-editor.org/rfc/rfc2119)
+
+RFC 8174
+"#;
+
+    let reports = Linter::<Text<String>>::default()
+        .clear_lints()
+        .deny("markdown-link-first-rfc", LinkFirst(RFC_PATTERN))
+        .check_slice(None, src)
+        .run()
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        reports,
+        r#"error[markdown-link-first-rfc]: the first match of the given pattern must be a link
+  |
+6 | RFC 8174
+  | ^^^^^^^^
+  |
+  = info: the pattern in question: `(?i)(rfc)\s+[0-9]+`
+"#
+    );
 }


### PR DESCRIPTION
## Summary

- Registers a default `markdown-link-first-rfc` lint using the existing configurable `LinkFirst` implementation.
- Matches case-insensitive `RFC <number>` references and requires the first mention of each RFC to be a Markdown link.
- Documents the new lint and adds regression coverage for unlinked-first, linked-first, and multiple-RFC cases.

## Implementation note

The RFC pattern captures the `RFC` prefix rather than the numeric identifier. `LinkFirst` uses capture group 1 only to exempt an EIP's own number; keeping that capture non-numeric prevents an EIP whose number happens to equal an RFC number from accidentally skipping the RFC check.

## Validation

- `cargo check --all --all-features --locked`
- `cargo test --all --no-default-features --locked`
- `cargo test --all --all-features --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --all-features -- --deny warnings`
- `wasm-pack test --node --all --locked`
